### PR TITLE
feat(ci): plugin release pipeline — auto-package, version bump, GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,164 @@
+name: Plugin Release
+
+# Triggers on every push to main — detects which plugins changed,
+# bumps their patch version, packages them, and creates GitHub releases.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/**'
+
+permissions:
+  contents: write  # needed to push version bump commit and create releases
+
+jobs:
+  # ── Job 1: Detect which plugins changed ─────────────────────────
+  detect:
+    name: Detect Changed Plugins
+    runs-on: ubuntu-latest
+    outputs:
+      plugins: ${{ steps.detect.outputs.plugins }}
+      has_changes: ${{ steps.detect.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2   # need parent commit for diff
+
+      - name: Detect changed plugins
+        id: detect
+        run: |
+          chmod +x scripts/detect-changed-plugins.sh
+          CHANGED=$(bash scripts/detect-changed-plugins.sh ${{ github.event.before }} ${{ github.sha }} || true)
+
+          if [[ -z "$CHANGED" ]]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "plugins=[]" >> $GITHUB_OUTPUT
+            echo "No plugin changes detected"
+          else
+            # Build JSON array for matrix strategy
+            JSON=$(echo "$CHANGED" | python3 -c "import sys,json; lines=[l.strip() for l in sys.stdin if l.strip()]; print(json.dumps(lines))")
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "plugins=$JSON" >> $GITHUB_OUTPUT
+            echo "Changed plugins: $CHANGED"
+          fi
+
+  # ── Job 2: Build, bump version, package, and release ─────────────
+  release:
+    name: Release ${{ matrix.plugin }}
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.has_changes == 'true'
+    strategy:
+      matrix:
+        plugin: ${{ fromJson(needs.detect.outputs.plugins) }}
+      fail-fast: false  # release other plugins even if one fails
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # ── Validate plugin structure ──────────────────────────────
+      - name: Validate plugin structure
+        run: |
+          PLUGIN="${{ matrix.plugin }}"
+          echo "Validating $PLUGIN..."
+
+          if [[ ! -d "plugins/$PLUGIN/.claude-plugin" ]]; then
+            echo "::error::Missing .claude-plugin/ in plugins/$PLUGIN — skipping"
+            exit 1
+          fi
+
+          if [[ ! -f "plugins/$PLUGIN/.claude-plugin/plugin.json" ]]; then
+            echo "::error::Missing plugin.json in plugins/$PLUGIN/.claude-plugin"
+            exit 1
+          fi
+
+          echo "✓ Plugin structure valid"
+
+      # ── Bump patch version ─────────────────────────────────────
+      - name: Bump version
+        id: bump
+        run: |
+          chmod +x scripts/bump-version.sh
+          bash scripts/bump-version.sh ${{ matrix.plugin }} patch
+
+      # ── Commit version bump ────────────────────────────────────
+      - name: Commit version bump
+        run: |
+          PLUGIN="${{ matrix.plugin }}"
+          NEW_VERSION="${{ steps.bump.outputs.new_version }}"
+          git add "plugins/$PLUGIN/.claude-plugin/plugin.json"
+          git commit -m "chore(release): bump $PLUGIN to v$NEW_VERSION [skip ci]"
+          git push
+
+      # ── Package the plugin ─────────────────────────────────────
+      - name: Package plugin
+        id: package
+        run: |
+          chmod +x scripts/package-plugin.sh
+          bash scripts/package-plugin.sh ${{ matrix.plugin }} dist
+
+      # ── Generate release notes ─────────────────────────────────
+      - name: Generate release notes
+        id: notes
+        run: |
+          PLUGIN="${{ matrix.plugin }}"
+          VERSION="${{ steps.bump.outputs.new_version }}"
+          OLD_VERSION="${{ steps.bump.outputs.old_version }}"
+
+          # Get commits that touched this plugin since last version tag
+          TAG="$PLUGIN-v$OLD_VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            COMMITS=$(git log "$TAG"..HEAD --oneline -- "plugins/$PLUGIN/" 2>/dev/null | head -20)
+          else
+            COMMITS=$(git log --oneline -10 -- "plugins/$PLUGIN/" 2>/dev/null)
+          fi
+
+          DESCRIPTION=$(python3 -c "import json; d=json.load(open('plugins/$PLUGIN/.claude-plugin/plugin.json')); print(d.get('description',''))" 2>/dev/null || echo "")
+
+          NOTES="## $PLUGIN v$VERSION
+
+$DESCRIPTION
+
+### Changes since v$OLD_VERSION
+\`\`\`
+${COMMITS:-No commit history found}
+\`\`\`
+
+### Installation
+Add this plugin in Claude Desktop → Settings → Plugins → Marketplaces → \`MSApps-Mobile/claude-plugins\`
+
+Or install the \`.plugin\` file directly for offline use."
+
+          # Write to temp file (avoids multiline GITHUB_OUTPUT issues)
+          echo "$NOTES" > /tmp/release_notes.md
+          echo "notes_file=/tmp/release_notes.md" >> $GITHUB_OUTPUT
+
+      # ── Create GitHub Release ──────────────────────────────────
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ matrix.plugin }}-v${{ steps.bump.outputs.new_version }}
+          name: "${{ matrix.plugin }} v${{ steps.bump.outputs.new_version }}"
+          body_path: ${{ steps.notes.outputs.notes_file }}
+          files: dist/${{ matrix.plugin }}-${{ steps.bump.outputs.new_version }}.plugin
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "### ✅ Released ${{ matrix.plugin }} v${{ steps.bump.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Previous version:** ${{ steps.bump.outputs.old_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **New version:** ${{ steps.bump.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Package:** \`${{ matrix.plugin }}-${{ steps.bump.outputs.new_version }}.plugin\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,221 @@
+name: Validate Plugin PR
+
+# Runs on every PR targeting main that touches plugins/
+# Validates structure, plugin.json schema, and SOSA compliance.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'plugins/**'
+      - 'scripts/**'
+
+jobs:
+  # ── Job 1: Detect which plugins are in this PR ───────────────────
+  detect:
+    name: Detect Changed Plugins
+    runs-on: ubuntu-latest
+    outputs:
+      plugins: ${{ steps.detect.outputs.plugins }}
+      has_plugins: ${{ steps.detect.outputs.has_plugins }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed plugins
+        id: detect
+        run: |
+          CHANGED=$(git diff --name-only origin/main...HEAD | grep '^plugins/' | cut -d'/' -f2 | sort -u || true)
+
+          if [[ -z "$CHANGED" ]]; then
+            echo "has_plugins=false" >> $GITHUB_OUTPUT
+            echo "plugins=[]" >> $GITHUB_OUTPUT
+          else
+            JSON=$(echo "$CHANGED" | python3 -c "import sys,json; lines=[l.strip() for l in sys.stdin if l.strip()]; print(json.dumps(lines))")
+            echo "has_plugins=true" >> $GITHUB_OUTPUT
+            echo "plugins=$JSON" >> $GITHUB_OUTPUT
+            echo "Plugins in this PR: $CHANGED"
+          fi
+
+  # ── Job 2: Validate each changed plugin ─────────────────────────
+  validate:
+    name: Validate ${{ matrix.plugin }}
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.has_plugins == 'true'
+    strategy:
+      matrix:
+        plugin: ${{ fromJson(needs.detect.outputs.plugins) }}
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── 1. Structure check ─────────────────────────────────────
+      - name: Check plugin structure
+        run: |
+          PLUGIN="${{ matrix.plugin }}"
+          ERRORS=0
+
+          if [[ ! -d "plugins/$PLUGIN/.claude-plugin" ]]; then
+            echo "::error file=plugins/$PLUGIN::Missing .claude-plugin/ directory"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          if [[ ! -f "plugins/$PLUGIN/.claude-plugin/plugin.json" ]]; then
+            echo "::error file=plugins/$PLUGIN/.claude-plugin/plugin.json::Missing plugin.json"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          if [[ ! -f "plugins/$PLUGIN/README.md" ]]; then
+            echo "::warning file=plugins/$PLUGIN/README.md::Missing README.md — strongly recommended"
+          fi
+
+          SKILL_COUNT=$(find "plugins/$PLUGIN" -name "SKILL.md" | wc -l)
+          if [[ "$SKILL_COUNT" -eq 0 ]]; then
+            echo "::error file=plugins/$PLUGIN::No SKILL.md found — every plugin needs at least one skill"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "✓ Found $SKILL_COUNT SKILL.md file(s)"
+          fi
+
+          if [[ "$ERRORS" -gt 0 ]]; then
+            exit 1
+          fi
+          echo "✓ Structure valid"
+
+      # ── 2. plugin.json schema validation ─────────────────────────
+      - name: Validate plugin.json schema
+        run: |
+          python3 - <<'PYEOF'
+          import json, sys, re, os
+
+          path = f"plugins/${{ matrix.plugin }}/.claude-plugin/plugin.json"
+
+          try:
+              with open(path) as f:
+                  d = json.load(f)
+          except Exception as e:
+              print(f"::error file={path}::Invalid JSON: {e}")
+              sys.exit(1)
+
+          errors = []
+          warnings = []
+
+          for field in ['name', 'version', 'description', 'author', 'license']:
+              if field not in d:
+                  errors.append(f"Missing required field: {field}")
+
+          ver = d.get('version', '')
+          if not re.match(r'^\d+\.\d+\.\d+$', ver):
+              errors.append(f"Invalid version format '{ver}' — must be semver (x.y.z)")
+
+          author = d.get('author', {})
+          if isinstance(author, dict) and 'name' not in author:
+              errors.append("author.name is required")
+
+          if 'sosa' not in d:
+              warnings.append("Missing sosa block — recommended for marketplace compliance")
+          else:
+              for pillar in ['supervised', 'orchestrated', 'secured', 'agents']:
+                  if pillar not in d['sosa'].get('pillars', {}):
+                      warnings.append(f"sosa.pillars.{pillar} not documented")
+
+          if 'platforms' not in d:
+              warnings.append("platforms not specified — recommended: ['claude-code', 'cowork']")
+
+          for w in warnings:
+              print(f"::warning file={path}::{w}")
+
+          if errors:
+              for e in errors:
+                  print(f"::error file={path}::{e}")
+              sys.exit(1)
+
+          print(f"✓ plugin.json valid (v{d.get('version','?')})")
+          PYEOF
+
+      # ── 3. SKILL.md quality check ─────────────────────────────
+      - name: Check SKILL.md quality
+        run: |
+          PLUGIN="${{ matrix.plugin }}"
+          ISSUES=0
+
+          while IFS= read -r skill_file; do
+            SKILL_NAME=$(dirname "$skill_file" | xargs basename)
+            WORD_COUNT=$(wc -w < "$skill_file")
+            LINE_COUNT=$(wc -l < "$skill_file")
+
+            if ! head -3 "$skill_file" | grep -q "^---"; then
+              echo "::error file=$skill_file::Missing YAML frontmatter (---)"
+              ISSUES=$((ISSUES + 1))
+            fi
+
+            if [[ "$WORD_COUNT" -gt 3000 ]]; then
+              echo "::warning file=$skill_file::$SKILL_NAME is $WORD_COUNT words — exceeds 3000 word budget"
+            fi
+
+            echo "✓ $SKILL_NAME: ${WORD_COUNT}w / ${LINE_COUNT}l"
+          done < <(find "plugins/$PLUGIN" -name "SKILL.md")
+
+          if [[ "$ISSUES" -gt 0 ]]; then
+            exit 1
+          fi
+
+      # ── 4. Secret scan ────────────────────────────────────────
+      - name: Scan for hardcoded secrets
+        run: |
+          PLUGIN="${{ matrix.plugin }}"
+          FOUND=0
+
+          PATTERNS=(
+            'api[_-]?key\s*[=:]\s*["\x27][A-Za-z0-9_\-]{10,}'
+            'secret\s*[=:]\s*["\x27][A-Za-z0-9_\-]{10,}'
+            'password\s*[=:]\s*["\x27][^"\x27]{6,}'
+            'token\s*[=:]\s*["\x27][A-Za-z0-9_\-\.]{20,}'
+            'sk-[a-zA-Z0-9]{20,}'
+            'xoxb-[0-9A-Za-z\-]+'
+          )
+
+          for pattern in "${PATTERNS[@]}"; do
+            if grep -rniP "$pattern" "plugins/$PLUGIN/" \
+               --include="*.ts" --include="*.js" --include="*.py" \
+               --include="*.json" --include="*.md" \
+               --exclude-dir="node_modules" 2>/dev/null; then
+              echo "::error::Potential hardcoded secret detected"
+              FOUND=1
+            fi
+          done
+
+          if find "plugins/$PLUGIN" -name ".env" | grep -q .; then
+            echo "::error::.env file found — never commit secrets"
+            FOUND=1
+          fi
+
+          if [[ "$FOUND" -eq 1 ]]; then exit 1; fi
+          echo "✓ No secrets detected"
+
+      # ── 5. Dry-run package build ───────────────────────────────
+      - name: Dry-run package build
+        run: |
+          chmod +x scripts/package-plugin.sh
+          bash scripts/package-plugin.sh ${{ matrix.plugin }} /tmp/dist-test
+          echo "✓ Package build succeeded"
+
+  # ── Job 3: SOSA compliance (repo-wide) ──────────────────────────
+  sosa:
+    name: SOSA Compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: SOSA lint
+        run: |
+          chmod +x scripts/sosa-lint.sh
+          bash scripts/sosa-lint.sh .
+
+      - name: SOSA eval (CI gate)
+        run: |
+          chmod +x scripts/sosa-eval.sh
+          bash scripts/sosa-eval.sh . --ci

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# ╔═══════════════════════════════════════════════════╗
+# ║  bump-version.sh                                  ║
+# ║  Bumps patch version in .claude-plugin/plugin.json║
+# ╚═══════════════════════════════════════════════════╝
+#
+# Usage: ./scripts/bump-version.sh <plugin-name> [major|minor|patch]
+# Default bump type: patch
+
+set -euo pipefail
+
+PLUGIN_NAME="${1:?Usage: bump-version.sh <plugin-name> [major|minor|patch]}"
+BUMP_TYPE="${2:-patch}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PLUGIN_JSON="$REPO_ROOT/plugins/$PLUGIN_NAME/.claude-plugin/plugin.json"
+
+if [[ ! -f "$PLUGIN_JSON" ]]; then
+  echo "::error::plugin.json not found: $PLUGIN_JSON"
+  exit 1
+fi
+
+CURRENT=$(python3 -c "import json; d=json.load(open('$PLUGIN_JSON')); print(d['version'])")
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+case "$BUMP_TYPE" in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+  *)
+    echo "::error::Invalid bump type '$BUMP_TYPE'. Use major|minor|patch"
+    exit 1
+    ;;
+esac
+
+NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+
+python3 - <<PYEOF
+import json
+path = "$PLUGIN_JSON"
+with open(path) as f:
+    data = json.load(f)
+data['version'] = "$NEW_VERSION"
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+    f.write('\n')
+print(f"✓ Bumped $PLUGIN_NAME: $CURRENT → $NEW_VERSION")
+PYEOF
+
+echo "new_version=$NEW_VERSION" >> "${GITHUB_OUTPUT:-/dev/null}" 2>/dev/null || true
+echo "old_version=$CURRENT" >> "${GITHUB_OUTPUT:-/dev/null}" 2>/dev/null || true

--- a/scripts/detect-changed-plugins.sh
+++ b/scripts/detect-changed-plugins.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# ╔═══════════════════════════════════════════════════╗
+# ║  detect-changed-plugins.sh                        ║
+# ║  Outputs newline-separated list of plugin dirs    ║
+# ║  that changed between BASE_SHA and HEAD_SHA       ║
+# ╚═══════════════════════════════════════════════════╝
+#
+# Usage: ./scripts/detect-changed-plugins.sh <base_sha> <head_sha>
+# Output: one plugin name per line (e.g. "whatsapp-mcp")
+#
+# In GitHub Actions, call as:
+#   CHANGED=$(bash scripts/detect-changed-plugins.sh ${{ github.event.before }} ${{ github.sha }})
+
+set -euo pipefail
+
+BASE_SHA="${1:-HEAD~1}"
+HEAD_SHA="${2:-HEAD}"
+
+# Get all changed files between the two commits
+CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+
+# Extract unique plugin names from changed paths like plugins/{name}/...
+PLUGINS=()
+while IFS= read -r file; do
+  if [[ "$file" == plugins/* ]]; then
+    plugin_name=$(echo "$file" | cut -d'/' -f2)
+    if [[ -n "$plugin_name" ]] && [[ -d "plugins/$plugin_name" ]]; then
+      PLUGINS+=("$plugin_name")
+    fi
+  fi
+done <<< "$CHANGED_FILES"
+
+# Deduplicate
+UNIQUE_PLUGINS=($(printf '%s\n' "${PLUGINS[@]}" | sort -u))
+
+if [[ ${#UNIQUE_PLUGINS[@]} -eq 0 ]]; then
+  echo "::notice::No plugin directories changed — skipping release"
+  exit 0
+fi
+
+for plugin in "${UNIQUE_PLUGINS[@]}"; do
+  echo "$plugin"
+done

--- a/scripts/package-plugin.sh
+++ b/scripts/package-plugin.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# ╔═══════════════════════════════════════════════════╗
+# ║  package-plugin.sh                                ║
+# ║  Packages a plugin's .claude-plugin/ directory    ║
+# ║  into a distributable .plugin zip file            ║
+# ╚═══════════════════════════════════════════════════╝
+#
+# Usage: ./scripts/package-plugin.sh <plugin-name> [output-dir]
+#
+# Input:  plugins/{name}/.claude-plugin/
+# Output: {output-dir}/{name}-{version}.plugin
+#
+# The .plugin format is a zip archive of the .claude-plugin/ directory.
+# The root of the zip IS the .claude-plugin/ directory contents
+# (not nested under another folder).
+
+set -euo pipefail
+
+PLUGIN_NAME="${1:?Usage: package-plugin.sh <plugin-name> [output-dir]}"
+OUTPUT_DIR="${2:-dist}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PLUGIN_DIR="$REPO_ROOT/plugins/$PLUGIN_NAME"
+CLAUDE_PLUGIN_DIR="$PLUGIN_DIR/.claude-plugin"
+
+# ── Validation ──────────────────────────────────────
+if [[ ! -d "$PLUGIN_DIR" ]]; then
+  echo "::error::Plugin directory not found: $PLUGIN_DIR"
+  exit 1
+fi
+
+if [[ ! -d "$CLAUDE_PLUGIN_DIR" ]]; then
+  echo "::error::Missing .claude-plugin/ directory in $PLUGIN_DIR"
+  exit 1
+fi
+
+if [[ ! -f "$CLAUDE_PLUGIN_DIR/plugin.json" ]]; then
+  echo "::error::Missing plugin.json in $CLAUDE_PLUGIN_DIR"
+  exit 1
+fi
+
+# ── Read version from plugin.json ───────────────────
+VERSION=$(python3 -c "import json; d=json.load(open('$CLAUDE_PLUGIN_DIR/plugin.json')); print(d['version'])" 2>/dev/null)
+if [[ -z "$VERSION" ]]; then
+  echo "::error::Could not read version from plugin.json"
+  exit 1
+fi
+
+# ── Prepare output dir ──────────────────────────────
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_FILE="$OUTPUT_DIR/$PLUGIN_NAME-$VERSION.plugin"
+
+# Remove any existing build for this version
+rm -f "$OUTPUT_FILE"
+
+# ── Create the zip ──────────────────────────────────
+# We zip the CONTENTS of .claude-plugin/ so the archive root
+# contains plugin.json, skills/, agents/, etc. directly.
+cd "$CLAUDE_PLUGIN_DIR"
+zip -r "$OLDPWD/$OUTPUT_FILE" . \
+  --exclude "*.DS_Store" \
+  --exclude "__pycache__/*" \
+  --exclude "*.pyc" \
+  --exclude "node_modules/*" \
+  --exclude ".git/*"
+cd "$OLDPWD"
+
+# ── Verify ──────────────────────────────────────────
+if [[ ! -f "$OUTPUT_FILE" ]]; then
+  echo "::error::Package creation failed — file not found: $OUTPUT_FILE"
+  exit 1
+fi
+
+SIZE=$(du -sh "$OUTPUT_FILE" | cut -f1)
+echo "✓ Packaged $PLUGIN_NAME v$VERSION → $OUTPUT_FILE ($SIZE)"
+
+# Output for GitHub Actions step chaining
+echo "plugin_file=$OUTPUT_FILE" >> "${GITHUB_OUTPUT:-/dev/null}" 2>/dev/null || true
+echo "plugin_version=$VERSION" >> "${GITHUB_OUTPUT:-/dev/null}" 2>/dev/null || true


### PR DESCRIPTION
## What this adds

A complete CI/CD pipeline for the plugin lifecycle — the missing half after SOSA lint already validates PRs.

## New workflows

### `release.yml` — fires on every push to `main` that touches `plugins/`
1. **Detects** which plugin directories changed (using the new `detect-changed-plugins.sh`)
2. **Bumps** the patch version in `plugin.json` and commits it back with `[skip ci]`
3. **Packages** the `.claude-plugin/` directory into a `{name}-{version}.plugin` zip
4. **Creates a GitHub Release** with the `.plugin` file attached as a downloadable artifact
5. Runs plugins **in parallel** via matrix strategy — one plugin failing won't block others

### `validate-pr.yml` — fires on PRs to `main` touching `plugins/` or `scripts/`
Per-plugin validation (parallel matrix):
- Structure check: `.claude-plugin/` dir, `plugin.json`, at least one `SKILL.md`
- `plugin.json` schema: required fields, semver format, `author.name`, SOSA block, platforms
- SKILL.md quality: YAML frontmatter present, word count within 3000-word budget
- Secret scan: regex patterns for API keys, tokens, passwords, `.env` files
- Dry-run package build: confirms the plugin can actually be packaged

Plus the existing SOSA lint + eval as a repo-wide job.

## New scripts

| Script | Purpose |
|--------|---------|
| `detect-changed-plugins.sh` | Diffs two SHAs, outputs unique plugin names that changed |
| `package-plugin.sh` | Zips `.claude-plugin/` into `{name}-{version}.plugin` |
| `bump-version.sh` | Bumps semver in `plugin.json` (major/minor/patch) |

## Before / After

| Before | After |
|--------|-------|
| Push to main → nothing | Push to main → auto-release with `.plugin` artifact |
| PR → SOSA lint only | PR → full structure + schema + secret + package validation |
| Manual version bumping | Automated patch bump on every merge |
| No packaged artifacts | Tagged GitHub Release per plugin per version |

## Notes
- The `[skip ci]` tag on version bump commits prevents infinite release loops
- `fail-fast: false` on the matrix means a bad plugin doesn't block others from releasing
- Requires no additional secrets — uses `GITHUB_TOKEN` throughout

🤖 Generated with Claude Sonnet 4.6