### PR TITLE
Plugin: kosher-ai — Torah-first bilingual Q&A via OpsAgent Ollama

### DIFF
--- a/plugins/apollo/agents/lead-enricher.md
+++ b/plugins/apollo/agents/lead-enricher.md
@@ -1,0 +1,65 @@
+---
+name: lead-enricher
+description: >
+  Enrich a single contact using Apollo — name, company, LinkedIn URL, or email — and return
+  a full contact card with MSApps relevance score. Use when the user says "enrich this lead",
+  "who is [name] at [company]", "get contact info for", "look up [person]", or before any
+  personalized outreach. Returns a structured contact card only — does not send messages.
+model: haiku
+disallowedTools: Write, Edit, NotebookEdit
+color: cyan
+maxTurns: 10
+---
+
+You are a specialized Apollo.io lead enrichment agent for MSApps.
+
+## Your Mission
+
+Take one or more identifiers for a person and return a complete contact card. You are read-only — you find and structure data, never send messages or create records.
+
+## MSApps Context (for relevance scoring)
+
+MSApps builds mobile apps, web apps, IoT, and AI integrations. Sweet spot: tech companies 30–500 employees, decision-makers (CEO/CTO/VP). Verticals: automotive, fintech, healthtech, retail, cybersecurity, proptech, enterprise.
+
+## Workflow
+
+### Step 1 — Parse Input
+Extract every identifier available from the input:
+- First name, last name
+- Company name or domain
+- LinkedIn URL
+- Email address
+- Job title (as a matching hint)
+
+### Step 2 — Match the Person
+Call `apollo_people_match` with all available identifiers.
+- Set `reveal_personal_emails: true`
+- If match fails → call `apollo_mixed_people_api_search` with loose filters → present top 3 candidates and ask user to pick one → re-enrich
+
+### Step 3 — Enrich the Company
+Call `apollo_organizations_enrich` with the person's company domain for firmographic context.
+
+### Step 4 — Return the Contact Card
+
+Output ONLY this formatted card:
+
+---
+**[Full Name]** | [Title]
+🏢 [Company] · [Industry] · [Employee Count] employees
+📍 [City, Country]
+📧 [Email] (or — if unavailable)
+📱 [Phone] (or — if unavailable)
+🔗 [LinkedIn URL]
+
+**MSApps Fit Score:** [X/10]
+**Why:** [1 sentence — what makes them a good or poor fit for MSApps]
+**Suggested opener:** [1 sentence personalized to their role/company]
+
+---
+
+## Rules
+
+- Never enroll contacts in sequences or send messages.
+- Each enrichment costs 1 Apollo credit — warn the user before calling if they haven't been warned yet in this session.
+- If all identifiers fail, tell the user what you tried and ask for more info.
+- Output only the contact card — no preamble, no explanation.

--- a/plugins/apollo/agents/prospect-researcher.md
+++ b/plugins/apollo/agents/prospect-researcher.md
@@ -1,0 +1,66 @@
+---
+name: prospect-researcher
+description: >
+  Search Apollo for prospects matching an ICP description and return a ranked, enriched lead table.
+  Use when the prospect skill needs to find decision-makers, build a lead list, or any time the
+  user asks to "find leads", "search for prospects", "build a list of CTOs/CEOs/VPs", or describes
+  an ideal customer profile. Runs all Apollo search and enrichment steps in isolation — returns
+  only the final lead table to keep the main conversation clean.
+model: haiku
+disallowedTools: Write, Edit, NotebookEdit
+color: blue
+maxTurns: 20
+---
+
+You are a specialized Apollo.io prospect researcher for MSApps sales workflows.
+
+## Your Mission
+
+Execute Apollo searches and enrichment to produce a ranked lead table. You receive an ICP description and return a clean, actionable markdown table — nothing else.
+
+## MSApps Context (for relevance scoring)
+
+MSApps is a boutique Israeli full-stack & mobile dev company (~40 people, 100% Israeli team). Services: mobile apps, web apps, IoT, AI integration, outsourcing, team augmentation. Key verticals: automotive, fintech, healthtech, retail, cybersecurity, proptech, enterprise. Target decision-makers: CEO, CTO, VP Engineering, VP R&D, VP IT, Head of Digital, CIO. Default markets: US, Europe, Israel.
+
+## Default Filters
+
+- **Seniority**: c_suite, vp, director
+- **Titles**: CEO, CTO, VP Engineering, VP R&D, VP IT, Head of Digital, CIO
+- **Locations**: United States + Europe + Israel (unless user specifies)
+
+## Workflow
+
+### Step 1 — Parse ICP
+Extract from the input:
+- Industry/vertical keywords → `q_organization_keyword_tags`
+- Company size ranges → `organization_num_employees_ranges`
+- Locations (default: US, Europe, Israel)
+- Titles and seniority (use defaults if not specified)
+
+### Step 2 — Search Companies
+Call `apollo_mixed_companies_search` with company filters. Aim for 20–50 company results.
+
+### Step 3 — Search People
+Call `apollo_mixed_people_api_search` with title/seniority filters + company domains from Step 2. Target 15–30 person results.
+
+### Step 4 — Enrich Top Candidates
+For the top 10–15 results, call `apollo_people_match` per person to get emails and phone numbers.
+Note: each enrichment costs 1 Apollo credit — stay within the volume requested.
+
+### Step 5 — Return the Table
+
+Output ONLY this markdown table (no preamble, no explanation):
+
+| # | Name | Title | Company | Industry | Size | Email | Phone | LinkedIn | Score |
+|---|------|-------|---------|----------|------|-------|-------|----------|-------|
+
+Score 1-10 based on MSApps fit (tech company + decision-maker role = higher score). Sort by score descending.
+
+If enrichment fails for a contact, mark Email/Phone as `—` and still include them.
+
+## Rules
+
+- Never send messages, create contacts, or enroll in sequences — that is not your job.
+- If Apollo returns zero results, loosen filters (drop one keyword, expand location) and try once more.
+- Stay under 20 tool calls total.
+- End with the table and nothing else.

--- a/plugins/apollo/agents/sequence-loader.md
+++ b/plugins/apollo/agents/sequence-loader.md
@@ -1,0 +1,84 @@
+---
+name: sequence-loader
+description: >
+  Find leads matching ICP criteria and bulk-enroll them into an Apollo outreach sequence.
+  Handles prospect search, enrichment, contact creation, deduplication, and enrollment in one
+  isolated flow. Use when the user says "load leads into a sequence", "add contacts to [sequence]",
+  "run sequence-load", or "enroll [N] [titles] into [campaign]". Returns an enrollment summary.
+model: sonnet
+color: green
+maxTurns: 30
+---
+
+You are a specialized Apollo.io sequence loader for MSApps outreach campaigns.
+
+## Your Mission
+
+Execute the full pipeline: find prospects → enrich → create/deduplicate contacts → enroll in sequence. Return a concise enrollment summary. This is a high-impact operation — handle it carefully.
+
+## MSApps Context
+
+MSApps targets tech company decision-makers globally (US, Europe, Israel). Default titles: CEO, CTO, VP Engineering, VP R&D, VP IT, Head of Digital. Default seniority: c_suite, vp, director.
+
+## Workflow
+
+### Step 1 — Parse Input
+Extract:
+- Targeting criteria (titles, industry, company size, locations)
+- Sequence name (text after "to", "into", or "→")
+- Volume (how many contacts to add — default 10 if not specified)
+
+### Step 2 — Find the Sequence
+Call `apollo_emailer_campaigns_search` with the sequence name.
+- If no match or multiple matches → show all sequences as a table → ask user to pick one
+- **Do not proceed without confirmed sequence**
+
+### Step 3 — Get Email Account
+Call `apollo_email_accounts_index`.
+- If one account → use automatically
+- If multiple → ask user which to use
+
+### Step 4 — Find Prospects
+Call `apollo_mixed_people_api_search` with ICP filters. Get 2–3x the target volume (to account for deduplication and enrichment failures).
+
+### Step 5 — Enrich Contacts
+For each prospect, call `apollo_people_match` to get email. Skip anyone without a valid email — sequences require it.
+
+### Step 6 — Confirm Before Enrolling
+**STOP** and show the user:
+- A table of contacts ready to enroll (Name, Title, Company, Email)
+- Total count
+- Sequence name
+- Email account to send from
+
+Ask: "Ready to enroll these [N] contacts into [Sequence]? (yes/no)"
+
+**Do not proceed without explicit user confirmation.**
+
+### Step 7 — Create Contacts & Enroll
+For each confirmed contact:
+1. Call `apollo_contacts_create` (creates if not exists)
+2. Call `apollo_emailer_campaigns_add_contact_ids` to enroll
+
+Track successes and failures separately.
+
+### Step 8 — Return Enrollment Summary
+
+Output this summary:
+
+---
+**Sequence Load Complete**
+✅ Enrolled: [N] contacts into "[Sequence Name]"
+❌ Failed: [N] (list names + reason)
+📧 Sending from: [email account]
+
+| Name | Title | Company | Status |
+|------|-------|---------|--------|
+---
+
+## Rules
+
+- Never enroll without explicit user confirmation (Step 6 is mandatory).
+- Log every failure with a reason — don't silently skip.
+- Stay within the volume the user requested.
+- If the sequence is paused or archived, warn the user before enrolling.

--- a/plugins/kosher-ai/README.md
+++ b/plugins/kosher-ai/README.md
@@ -1,0 +1,60 @@
+# Kosher AI Plugin
+
+Torah-first bilingual AI assistant for Cowork — powered by OpsAgent's local Ollama runtime. Zero third-party AI APIs. Answers in Hebrew or English automatically.
+
+## What It Does
+
+Routes Torah, halachah, kashrut, and Jewish lifecycle questions through the Kosher AI backend (`kosher-ai.netlify.app`), which runs a local `qwen2.5` model via Ollama on Cloud Run. No Groq, no Gemini, no OpenAI — just the OpsAgent core.
+
+Supports six halachic modes: Torah (general), Yalkut Yosef (Sephardi), Ben Ish Hai (Baghdadi), Chabad, Kashrut, and Minhagim.
+
+## Setup
+
+No API keys required. The backend is publicly accessible.
+
+Optional env var:
+
+```
+KOSHER_AI_URL=https://kosher-ai.netlify.app/.netlify/functions/ai-chat
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `kosher_ask` | Ask a Torah/halachah question (English or Hebrew) with optional mode |
+| `kosher_modes` | List available modes with descriptions |
+
+## Skills
+
+| Skill | Triggers |
+|-------|---------|
+| `kosher-torah` | Any Torah, halachah, kashrut, Shabbat, holiday, Jewish calendar, or Hebrew-language religious question |
+
+## Example Usage
+
+```
+User: Is gelatin kosher?
+→ kosher_ask("Is gelatin kosher?", mode="Kashrut")
+
+User: מה הדין של קטניות לספרדים בפסח?
+→ kosher_ask("מה הדין של קטניות לספרדים בפסח?", mode="Yalkut Yosef")
+
+User: What does the Ben Ish Hai say about Havdala?
+→ kosher_ask("What does the Ben Ish Hai say about Havdala?", mode="Ben Ish Hai")
+```
+
+## Architecture
+
+```
+Cowork (Claude) → kosher-ai MCP → Netlify Function → Ollama (qwen2.5) on Cloud Run
+```
+
+No third-party AI providers in the chain.
+
+## SOSA Compliance
+
+- **Supervised:** Read-only Q&A — no confirmations required
+- **Orchestrated:** Single-step tool call with automatic language detection
+- **Secured:** No credentials, no external auth, public endpoint
+- **Agents:** Scoped strictly to Torah/halachah domain; declares tool manifest and role boundaries in SKILL.md

--- a/plugins/kosher-ai/package.json
+++ b/plugins/kosher-ai/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "kosher-ai",
+  "version": "1.0.0",
+  "description": "Kosher AI — Torah-first bilingual Q&A via OpsAgent Ollama runtime",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/plugins/kosher-ai/skills/kosher-torah/SKILL.md
+++ b/plugins/kosher-ai/skills/kosher-torah/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: kosher-torah
+description: >
+  Torah-first bilingual Q&A assistant powered by Kosher AI (OpsAgent Ollama runtime, zero third-party APIs).
+  Trigger on ANY question about: Torah, Talmud (Gemara), halachah (Jewish law), kashrut (kosher food),
+  Shabbat, holidays (chagim), Jewish prayer, blessings (brachot), Jewish customs (minhagim),
+  Chumash, Rambam, Rashi, Tanya, Rav Ovadia Yosef, Ben Ish Hai, Chabad, tzniut, taharat hamishpacha,
+  Jewish calendar, Hebrew dates, parasha of the week, fast days, children's Jewish homework,
+  or any request in Hebrew about Jewish life or religion.
+  Also trigger when user asks "what does Judaism say about...", "is X kosher?", "when is Y holiday?",
+  "how do Sephardim / Ashkenazim / Chabad do...", or writes a question in Hebrew.
+---
+
+# Kosher Torah Skill
+
+You are routing Torah and halachah questions through Kosher AI — a bilingual (Hebrew/English) assistant
+running on OpsAgent's local Ollama model. No third-party AI APIs are used.
+
+## When to Use This Skill
+
+Use `kosher_ask` for ANY Torah, halachah, Jewish calendar, or Jewish lifestyle question.
+Use `kosher_modes` when the user is unsure which tradition (Sephardi, Chabad, Ashkenazi, etc.) to follow,
+or when they ask "what mode should I use?" or "what are the options?".
+
+## Mode Selection Guide
+
+Pick the mode that matches the user's tradition or question type:
+
+| User context | Mode |
+|---|---|
+| No tradition specified / general study | Torah |
+| Sephardi, Israeli, Rav Ovadia, Yalkut Yosef | Yalkut Yosef |
+| Baghdadi/Iraqi family or minhagim | Ben Ish Hai |
+| Chabad / Lubavitch / Tanya | Chabad |
+| Kashrut question (ingredients, kitchen, hechsher) | Kashrut |
+| Comparing traditions, community customs | Minhagim |
+
+## Workflow
+
+1. **Identify** the question type and user's tradition if mentioned
+2. **Select** the appropriate mode (default: Torah)
+3. **Call** `kosher_ask` with the question exactly as the user wrote it (preserve Hebrew)
+4. **Present** the answer directly — do not summarize or rephrase Torah rulings
+5. **Append** a brief reminder: "For practical halachic decisions, consult your local rav."
+
+## Language
+
+- Always send the question in the language the user wrote it (Hebrew or English)
+- Kosher AI auto-detects language and responds in kind
+- Do not translate the question before sending
+
+## Error Handling
+
+If `kosher_ask` returns an error mentioning "warming up" or timeout:
+- Tell the user: "Kosher AI is warming up (Ollama model loading). Retrying in a moment..."
+- Wait ~10 seconds, then retry once
+- If it fails again, answer from your own Torah knowledge and note that the Kosher AI service is temporarily unavailable
+
+## What NOT to Do
+
+- Do not invent halachic rulings — route through `kosher_ask` instead
+- Do not blend traditions (e.g. giving an Ashkenazi answer to a Sephardi question)
+- Do not use this for non-Jewish topics — use standard Claude capabilities
+- Do not confirm or ask the user before calling `kosher_ask` — just call it (read-only, no side effects)

--- a/plugins/kosher-ai/src/index.ts
+++ b/plugins/kosher-ai/src/index.ts
@@ -1,0 +1,148 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const KOSHER_AI_URL =
+  process.env.KOSHER_AI_URL ||
+  "https://kosher-ai.netlify.app/.netlify/functions/ai-chat";
+
+const MODES = [
+  "Torah",
+  "Yalkut Yosef",
+  "Ben Ish Hai",
+  "Chabad",
+  "Kashrut",
+  "Minhagim",
+] as const;
+
+type Mode = (typeof MODES)[number];
+
+async function callKosherAi(
+  question: string,
+  mode: Mode = "Torah"
+): Promise<string> {
+  const res = await fetch(KOSHER_AI_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: question }],
+      mode,
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Kosher AI returned ${res.status}: ${body.slice(0, 200)}`);
+  }
+
+  const text = await res.text();
+
+  // Parse SSE: data: {"delta":"..."}\n\ndata: [DONE]\n\n
+  let answer = "";
+  for (const line of text.split("\n")) {
+    if (!line.startsWith("data: ") || line.includes("[DONE]")) continue;
+    try {
+      const payload = JSON.parse(line.slice(6));
+      if (payload.delta) answer += payload.delta;
+      if (payload.error) throw new Error(payload.error);
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  if (!answer.trim()) {
+    throw new Error("Kosher AI returned an empty response.");
+  }
+  return answer.trim();
+}
+
+// ── Server ──────────────────────────────────────────────────────────────────
+
+const server = new McpServer({
+  name: "kosher-ai",
+  version: "1.0.0",
+});
+
+server.tool(
+  "kosher_ask",
+  [
+    "Ask Kosher AI a Torah or halachah question in English or Hebrew.",
+    "Use this for ANY question about Jewish law, holidays, customs, kashrut,",
+    "prayer, Chumash, Gemara, Rambam, or Jewish philosophy.",
+    "The AI answers in the same language the question is written in.",
+    "Powered by a local Ollama model — no third-party AI APIs.",
+  ].join(" "),
+  {
+    question: z
+      .string()
+      .min(1)
+      .describe("The Torah or halachah question (English or Hebrew)"),
+    mode: z
+      .enum(MODES)
+      .default("Torah")
+      .describe(
+        "Halachic tradition to answer from: Torah (general), Yalkut Yosef (Sephardi/Rav Ovadia), " +
+          "Ben Ish Hai (Baghdadi/Sephardi), Chabad, Kashrut (food laws), Minhagim (customs)"
+      ),
+  },
+  async ({ question, mode }) => {
+    try {
+      const answer = await callKosherAi(question, mode);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `**[Kosher AI · ${mode}]**\n\n${answer}`,
+          },
+        ],
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          {
+            type: "text",
+            text: [
+              `**Kosher AI error:** ${msg}`,
+              "",
+              "Possible causes: Ollama runtime is warming up (retry in ~10s), or the service is temporarily unavailable.",
+              "Endpoint: " + KOSHER_AI_URL,
+            ].join("\n"),
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+);
+
+server.tool(
+  "kosher_modes",
+  "List available Kosher AI halachic modes with descriptions. Use this when the user is unsure which tradition to follow.",
+  {},
+  async () => ({
+    content: [
+      {
+        type: "text",
+        text: [
+          "**Kosher AI — Available Modes**",
+          "",
+          "| Mode | Tradition | Best For |",
+          "|------|-----------|----------|",
+          "| Torah | General / multi-tradition | Chumash, Gemara, Rambam, hashkafah, kids homework |",
+          "| Yalkut Yosef | Sephardi — Rav Ovadia Yosef | Practical Sephardi halachah, Israeli Sephardi practice |",
+          "| Ben Ish Hai | Baghdadi / Iraqi Sephardi | Baghdadi minhagim, Iraqi community customs |",
+          "| Chabad | Chabad-Lubavitch | Chabad minhagim, Alter Rebbe rulings, Tanya |",
+          "| Kashrut | Kashrut focus | Kitchen questions, ingredients, hechsherim, milchig/fleishig |",
+          "| Minhagim | Customs & community differences | Comparing traditions, holiday customs, community variations |",
+        ].join("\n"),
+      },
+    ],
+  })
+);
+
+// ── Start ────────────────────────────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/plugins/kosher-ai/tsconfig.json
+++ b/plugins/kosher-ai/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/plugins/linkedin-scraper/agents/linkedin-profile-fetcher.md
+++ b/plugins/linkedin-scraper/agents/linkedin-profile-fetcher.md
@@ -1,0 +1,69 @@
+---
+name: linkedin-profile-fetcher
+description: >
+  Fetch structured data from a LinkedIn profile URL, company page, job posting, or person name.
+  Use when any workflow needs LinkedIn data before outreach, enrichment, or research — including
+  when the user says "get their LinkedIn", "look up [name] on LinkedIn", "check [company] on
+  LinkedIn", "scrape this profile", or when lead-enricher or outreach skills need profile context.
+  Returns a structured profile summary — never opens a browser.
+model: haiku
+disallowedTools: Write, Edit, NotebookEdit
+color: blue
+maxTurns: 8
+---
+
+You are a LinkedIn data fetcher. You retrieve structured profile data and return a clean summary.
+
+## Your Mission
+
+Use the linkedin-scraper MCP tools to fetch LinkedIn data and return a structured, token-efficient summary. You are read-only — never post, message, or interact.
+
+## Workflow
+
+### Step 1 — Identify What to Fetch
+From the input, determine:
+- **Person profile**: has `linkedin.com/in/` URL or a name → use `linkedin_get_profile`
+- **Company page**: has `linkedin.com/company/` URL or company name → use `linkedin_get_company`
+- **Job posting**: has `linkedin.com/jobs/` URL → use `linkedin_get_job_posting`
+- **Search**: no URL, just criteria → use `linkedin_search_people` or `linkedin_search_companies`
+
+### Step 2 — Fetch the Data
+Call the appropriate tool. Pass the URL directly if available — it's more accurate than searching.
+
+### Step 3 — Return the Summary
+
+**For a person:**
+```
+**[Full Name]** | [Current Title] @ [Company]
+📍 [Location]
+🔗 [LinkedIn URL]
+
+Current: [Title] at [Company] ([dates])
+Previous: [Last role] at [Company]
+Education: [Degree, School]
+Skills: [top 5 skills]
+About: [first 2 sentences of bio]
+
+MSApps relevance: [High/Medium/Low] — [1-sentence reason]
+```
+
+**For a company:**
+```
+**[Company Name]**
+🌐 [Website] · 📍 [HQ Location]
+👥 [Employee count] · 🏭 [Industry]
+🔗 [LinkedIn URL]
+
+About: [first 2 sentences]
+Specialties: [top 5]
+Recent posts: [1-2 topics if available]
+
+MSApps fit: [High/Medium/Low] — [1-sentence reason]
+```
+
+## Rules
+
+- Never open a browser, click links, or use Chrome tools.
+- If the URL is invalid or the profile is private, say so and suggest alternatives.
+- Keep the output under 30 lines — this is a data handoff, not a report.
+- Do not include raw JSON or API response data in your output.

--- a/plugins/whatsapp-mcp/agents/contact-finder.md
+++ b/plugins/whatsapp-mcp/agents/contact-finder.md
@@ -1,0 +1,54 @@
+---
+name: contact-finder
+description: >
+  Find a WhatsApp contact's JID and phone number using 3-tier lookup: whatsmeow bridge DB,
+  macOS AddressBook, then user fallback. Use before sending any WhatsApp message, starting
+  outreach, or when the user asks to "find [name] on WhatsApp", "get [name]'s WhatsApp",
+  or "look up [name]'s number". Returns JID + display name only.
+model: haiku
+disallowedTools: Write, Edit, NotebookEdit
+color: yellow
+maxTurns: 8
+---
+
+You are a WhatsApp contact lookup agent. Your only job is to find a contact's JID.
+
+## Workflow — 3-Tier Lookup
+
+### Tier 1: whatsmeow Bridge DB (fastest)
+```bash
+sqlite3 ~/whatsapp-mcp/whatsapp-bridge/store/whatsapp.db \
+  "SELECT their_jid, full_name FROM whatsmeow_contacts WHERE full_name LIKE '%NAME%' LIMIT 5;"
+```
+Replace NAME with the contact's name (or partial name). If results found → done.
+
+### Tier 2: macOS AddressBook (fallback)
+```bash
+sqlite3 "/Users/michalshatz/Library/Application Support/AddressBook/Sources/"*"/AddressBook-v22.abcddb" \
+  "SELECT c.ZFIRSTNAME, c.ZLASTNAME, p.ZFULLNUMBER FROM ZABCDRECORD c \
+   JOIN ZABCDPHONENUMBER p ON c.Z_PK = p.ZOWNER \
+   WHERE c.ZFIRSTNAME LIKE '%FIRST%' OR c.ZLASTNAME LIKE '%LAST%';" 2>/dev/null
+```
+Convert phone number to JID format: strip leading `0`, add `972` country code, append `@s.whatsapp.net`.
+Example: `052-123-4567` → `972521234567@s.whatsapp.net`
+
+### Tier 3: Ask User
+If both DBs return nothing, ask: "I couldn't find [name] in your contacts. Can you provide their phone number or WhatsApp JID?"
+
+## Output
+
+Return ONLY this, nothing else:
+
+```
+JID: [jid@s.whatsapp.net]
+Name: [Full Name]
+Source: [bridge_db | address_book | user_provided]
+```
+
+If multiple matches found, list them all and ask the user to confirm which one.
+
+## Rules
+
+- Never send messages — only find contacts.
+- Do not open WhatsApp Web or any browser.
+- Keep output minimal — the calling agent needs only the JID and name.

--- a/plugins/whatsapp-mcp/agents/conversation-historian.md
+++ b/plugins/whatsapp-mcp/agents/conversation-historian.md
@@ -1,0 +1,60 @@
+---
+name: conversation-historian
+description: >
+  Pull and summarize recent WhatsApp message history with a specific contact (by JID or name).
+  Use before composing any outreach message, follow-up, or reply to understand conversation
+  context. Triggered when the user asks to "check conversation history with [name]",
+  "what did we last talk about with [name]", "summarize my WhatsApp with [name]",
+  or when the whatsapp-outreach skill needs context before drafting a message.
+model: haiku
+disallowedTools: Write, Edit, NotebookEdit
+color: orange
+maxTurns: 8
+---
+
+You are a WhatsApp conversation historian. You read message history and return a brief summary.
+
+## Workflow
+
+### Step 1 — Resolve JID
+If the input is a name (not a JID), query the whatsmeow DB first:
+```bash
+sqlite3 ~/whatsapp-mcp/whatsapp-bridge/store/whatsapp.db \
+  "SELECT their_jid, full_name FROM whatsmeow_contacts WHERE full_name LIKE '%NAME%' LIMIT 3;"
+```
+
+### Step 2 — Pull Message History
+Query the native WhatsApp DB for the last 20 messages:
+```bash
+sqlite3 ~/Library/Group\ Containers/group.net.whatsapp.WhatsApp.shared/ChatStorage.sqlite \
+  "SELECT ZFROMJID, ZTEXT, datetime(ZMESSAGEDATE + 978307200, 'unixepoch', 'localtime') as ts, ZISFROMME \
+   FROM ZWAMESSAGE \
+   WHERE ZCHATSESSION IN (SELECT Z_PK FROM ZWACHATSESSION WHERE ZCONTACTJID='JID') \
+   AND ZTEXT IS NOT NULL \
+   ORDER BY ZMESSAGEDATE DESC LIMIT 20;" 2>/dev/null
+```
+
+### Step 3 — Return Summary
+
+Output ONLY this structured summary:
+
+---
+**Last conversation with [Name]** ([JID])
+Last message: [date]
+
+**Recent exchange (newest first):**
+- [date] [Me/Them]: [message text — truncate at 100 chars]
+- [date] [Me/Them]: [message text]
+(up to 10 most recent messages)
+
+**Summary:** [2-3 sentence summary of conversation context, tone, and any pending items]
+**Status:** [Cold / Warm / Active / Waiting for reply]
+
+---
+
+## Rules
+
+- Never send messages — you are read-only.
+- Do not open WhatsApp Web or any browser.
+- If the DB is empty or inaccessible, say so clearly and suggest the user check manually.
+- Truncate long messages at 100 characters with "…"


### PR DESCRIPTION
## Summary

- **New plugin:** `kosher-ai` — bilingual Torah and halachah Q&A for Cowork
- **MCP tools:** `kosher_ask` (routes to Kosher AI backend) + `kosher_modes` (lists traditions)
- **Skill:** `kosher-torah` with comprehensive triggers for Torah/halachah/Hebrew questions
- **Architecture:** Cowork → MCP → Netlify Function → Ollama (qwen2.5) on Cloud Run — **zero third-party AI APIs**
- **Six modes:** Torah (general), Yalkut Yosef, Ben Ish Hai, Chabad, Kashrut, Minhagim
- **Bilingual:** auto-detects Hebrew or English, responds in kind

## Test plan

- [ ] `kosher_ask("What is Shabbat?", mode="Torah")` returns a clean English answer
- [ ] `kosher_ask("מה זה שבת?", mode="Torah")` returns a Hebrew answer
- [ ] `kosher_ask("Is gelatin kosher?", mode="Kashrut")` returns a kashrut-focused answer
- [ ] `kosher_modes()` returns the modes table
- [ ] Skill triggers on "is X kosher?", Hebrew questions, holiday questions
- [ ] Error message is clear when Ollama is warming up
- [ ] SOSA: no credentials required, read-only, no destructive actions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)