### PR TITLE
Plugin: ollama-torah-mcp — generic Torah Q&A via Ollama

### DIFF
--- a/plugins/ollama-torah-mcp/.claude-plugin/plugin.json
+++ b/plugins/ollama-torah-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "ollama-torah-mcp",
+  "version": "0.1.0",
+  "description": "Torah Q&A MCP server powered by a local/remote Ollama instance \u2014 bilingual Hebrew/English halachic guidance with 6 specialized modes.",
+  "author": {
+    "name": "MSApps"
+  },
+  "keywords": [
+    "ollama",
+    "torah",
+    "halacha",
+    "hebrew",
+    "jewish-law",
+    "ai",
+    "mcp",
+    "sosa-agents"
+  ],
+  "sosa": {
+    "compliant": true,
+    "level": 2,
+    "impact": "low",
+    "methodology": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/SOSA.md",
+    "whitepaper": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/sosa-whitepaper.pdf",
+    "pillars": {
+      "supervised": "Read-only Torah Q&A \u2014 no destructive operations, no external writes",
+      "orchestrated": "Single Ollama endpoint, structured tool responses with mode selection",
+      "secured": "URL and model via env vars, Zod input validation, request timeout enforcement",
+      "agents": "R=torah-knowledge, T=Ollama API, M=conversation context, P=chat completion"
+    }
+  },
+  "topics": [
+    "sosa-agents"
+  ],
+  "license": "MIT",
+  "platforms": [
+    "claude-code",
+    "cowork"
+  ]
+}

--- a/plugins/ollama-torah-mcp/QA_TEST_PLAN.md
+++ b/plugins/ollama-torah-mcp/QA_TEST_PLAN.md
@@ -1,0 +1,206 @@
+# Ollama Torah MCP — QA Test Plan
+
+## Scope
+
+End-to-end testing of the `ollama-torah-mcp` plugin: MCP tools, halachic modes, error handling, bilingual support, and SOSA compliance.
+
+## Environment
+
+- **Ollama:** Local instance (`http://localhost:11434`)
+- **Model:** `qwen2.5:0.5b-instruct`
+- **MCP Inspector:** `npx @modelcontextprotocol/inspector`
+- **Claude Code / Cowork:** Desktop app with plugin installed
+
+---
+
+## Test Cases
+
+### TC-001: Health check — Ollama running
+**Priority**: P0
+**Type**: Functional
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Start Ollama (`ollama serve`) | Server starts on port 11434 |
+| 2 | Call `torah_health` | Returns "Healthy", lists model as loaded |
+| 3 | Verify response includes URL and model name | URL = localhost:11434, model = qwen2.5:0.5b-instruct |
+
+---
+
+### TC-002: Health check — Ollama NOT running
+**Priority**: P0
+**Type**: Error handling
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Stop Ollama | Server stopped |
+| 2 | Call `torah_health` | Returns "Unreachable" with clear instructions to run `ollama serve` |
+
+---
+
+### TC-003: Health check — model not pulled
+**Priority**: P1
+**Type**: Error handling
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Set OLLAMA_MODEL to `nonexistent-model:latest` | Env var set |
+| 2 | Call `torah_health` | Returns "Warning" with instruction to `ollama pull nonexistent-model:latest` |
+
+---
+
+### TC-004: Basic English question — Torah mode
+**Priority**: P0
+**Type**: Functional
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Call `torah_ask("What is Shabbat?", mode="Torah")` | Returns English answer about Shabbat |
+| 2 | Verify response contains `[Torah]` header | Header present |
+| 3 | Verify "consult your local rav" footer | Footer present |
+| 4 | Verify response is in English | English text |
+
+---
+
+### TC-005: Hebrew question — auto language
+**Priority**: P0
+**Type**: Functional / i18n
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Call `torah_ask("מה זה שבת?", mode="Torah")` | Returns Hebrew answer about Shabbat |
+| 2 | Verify response contains Hebrew characters | Hebrew text present |
+
+---
+
+### TC-006: All six modes return distinct answers
+**Priority**: P1
+**Type**: Functional
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Call `torah_ask("What is the blessing after bread?", mode="Torah")` | General answer about Birkat Hamazon |
+| 2 | Call same question with mode="Yalkut Yosef" | Sephardi-focused answer |
+| 3 | Call same question with mode="Ben Ish Hai" | Baghdadi-focused answer |
+| 4 | Call same question with mode="Chabad" | Chabad-focused answer |
+| 5 | Call same question with mode="Kashrut" | Kashrut-focused angle |
+| 6 | Call same question with mode="Minhagim" | Compares traditions |
+
+**Notes**: Answers should differ meaningfully across modes, not just change a header.
+
+---
+
+### TC-007: torah_modes returns complete table
+**Priority**: P1
+**Type**: Functional
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Call `torah_modes()` | Returns markdown table with all 6 modes |
+| 2 | Verify all modes present: Torah, Yalkut Yosef, Ben Ish Hai, Chabad, Kashrut, Minhagim | All 6 listed |
+
+---
+
+### TC-008: Timeout handling
+**Priority**: P1
+**Type**: Error handling
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Set REQUEST_TIMEOUT=100 (very short) | Env var set |
+| 2 | Call `torah_ask("Explain the 39 melachot in detail")` | Returns error with "timeout" message |
+| 3 | Verify error includes troubleshooting steps | Shows current timeout value, suggests increasing |
+
+---
+
+### TC-009: Context continuation
+**Priority**: P2
+**Type**: Functional
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Call `torah_ask("What is Havdala?", mode="Torah")` | Gets base answer |
+| 2 | Call `torah_ask("What spices are used?", mode="Torah", context="Q: What is Havdala? A: [previous answer]")` | Answer relates to Havdala spices specifically, not generic spice question |
+
+---
+
+### TC-010: Empty / invalid input
+**Priority**: P1
+**Type**: Validation
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Call `torah_ask("", mode="Torah")` | Returns validation error (min 1 char) |
+| 2 | Call `torah_ask("test", mode="InvalidMode")` | Returns validation error for invalid enum |
+
+---
+
+### TC-011: SOSA — read-only verification
+**Priority**: P0
+**Type**: Security / Compliance
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Review all tool implementations | No write operations, no side effects |
+| 2 | Call each tool 10 times | No state change on Ollama server |
+| 3 | Verify no credentials are logged or transmitted | Clean — only model name and question sent |
+
+---
+
+### TC-012: Custom Ollama URL
+**Priority**: P2
+**Type**: Configuration
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Set OLLAMA_URL to a remote Ollama instance | Env var set |
+| 2 | Call `torah_health` | Connects to remote instance |
+| 3 | Call `torah_ask("What is Shabbat?")` | Gets answer from remote model |
+
+---
+
+### TC-013: Skill trigger coverage
+**Priority**: P1
+**Type**: Integration / Skill
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | In Cowork, say "Is chicken parmesan kosher?" | torah-qa skill triggers, calls `torah_ask` with Kashrut mode |
+| 2 | Say "מתי צום גדליה?" | Skill triggers on Hebrew text |
+| 3 | Say "How do Chabad and Sephardim differ on Havdala?" | Triggers with Minhagim mode |
+| 4 | Say "What's the weather today?" | Skill does NOT trigger (non-Jewish topic) |
+
+---
+
+## Test Data
+
+### Hebrew Test Queries
+- `מה זה שבת?`
+- `מה הדין של בשר וחלב?`
+- `מתי ראש השנה?`
+- `איך מברכים על הלחם?`
+- `מה ההבדל בין ספרדים לאשכנזים בענייני כשרות?`
+
+### English Test Queries
+- "What is Shabbat?"
+- "Is gelatin kosher?"
+- "When is Yom Kippur?"
+- "Explain the mitzvah of tzedakah"
+- "What does the Rambam say about repentance?"
+
+### Edge Cases
+- Very long question (500+ chars)
+- Mixed Hebrew/English in one question
+- Question with no Jewish content ("What is Python?")
+- Emoji in question
+- Question about controversial topics ("Is X community right about Y?")
+
+---
+
+## Pass Criteria
+
+- All P0 tests pass
+- At least 90% of P1 tests pass
+- No security/SOSA violations in TC-011
+- Response time under 10 seconds on `qwen2.5:0.5b-instruct` (CPU)
+- Hebrew and English both produce coherent answers

--- a/plugins/ollama-torah-mcp/README.md
+++ b/plugins/ollama-torah-mcp/README.md
@@ -1,0 +1,67 @@
+# Ollama Torah MCP
+
+Torah and halachah Q&A plugin for Claude — powered by any Ollama instance. No third-party AI APIs. Bring your own model and endpoint.
+
+## What It Does
+
+Routes Torah, halachah, kashrut, and Jewish lifecycle questions through a local (or remote) Ollama model. Bilingual Hebrew/English with automatic language detection.
+
+Six halachic modes: Torah (general), Yalkut Yosef (Sephardi), Ben Ish Hai (Baghdadi), Chabad, Kashrut, and Minhagim.
+
+## Setup
+
+1. **Install Ollama** — [ollama.com](https://ollama.com/)
+2. **Pull a model** — `ollama pull qwen2.5:0.5b-instruct` (fast) or any model you prefer
+3. **Start Ollama** — `ollama serve`
+4. **Set env vars** (optional — defaults to localhost):
+
+```bash
+export OLLAMA_URL=http://localhost:11434
+export OLLAMA_MODEL=qwen2.5:0.5b-instruct
+export REQUEST_TIMEOUT=30000
+```
+
+Works with any Ollama-compatible endpoint (local, Cloud Run, Docker, etc.).
+
+## Tools
+
+| Tool | Description | Read-only |
+|------|-------------|-----------|
+| `torah_ask` | Ask a Torah/halachah question with optional mode | Yes |
+| `torah_modes` | List available halachic traditions | Yes |
+| `torah_health` | Check Ollama connectivity and model availability | Yes |
+
+## Skills
+
+| Skill | Triggers |
+|-------|---------|
+| `torah-qa` | Torah, halachah, kashrut, Shabbat, holidays, Jewish calendar, Hebrew questions |
+
+## Example Usage
+
+```
+User: Is gelatin kosher?
+→ torah_ask("Is gelatin kosher?", mode="Kashrut")
+
+User: מה הדין של קטניות בפסח?
+→ torah_ask("מה הדין של קטניות בפסח?", mode="Yalkut Yosef")
+
+User: What does the Ben Ish Hai say about Havdala?
+→ torah_ask("...", mode="Ben Ish Hai")
+```
+
+## Recommended Models
+
+| Model | Size | Speed (CPU) | Quality |
+|-------|------|-------------|---------|
+| `qwen2.5:0.5b-instruct` | 400MB | Fast (~3s) | Good for basic Q&A |
+| `qwen2.5:3b-instruct` | 2GB | Moderate (~15s) | Better reasoning |
+| `llama3:8b` | 4.7GB | Slow (~30s+) | Best quality, needs GPU |
+
+## SOSA Compliance
+
+- **Supervised:** All tools are read-only — no side effects, no confirmations needed
+- **Orchestrated:** Single-step tool calls with clear mode selection
+- **Secured:** No credentials required, no external auth, configurable endpoint
+- **Agents:** Scoped to Torah/halachah domain, declares boundaries in SKILL.md
+

--- a/plugins/ollama-torah-mcp/package.json
+++ b/plugins/ollama-torah-mcp/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ollama-torah-mcp",
+  "version": "1.0.0",
+  "description": "Torah & halachah Q&A MCP server backed by any Ollama instance — no third-party AI APIs",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  },
+  "keywords": ["mcp", "ollama", "torah", "halachah", "jewish", "kosher", "bilingual"],
+  "license": "MIT"
+}

--- a/plugins/ollama-torah-mcp/skills/torah-qa/SKILL.md
+++ b/plugins/ollama-torah-mcp/skills/torah-qa/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: torah-qa
+description: >
+  Torah and halachah Q&A using a local Ollama model — zero third-party AI APIs.
+  Trigger on ANY question about: Torah, Talmud, Gemara, halachah, Jewish law,
+  kashrut, Shabbat, Jewish holidays, Jewish prayer, blessings (brachot),
+  Jewish customs, Chumash, Rambam, Rashi, Tanya, Rav Ovadia Yosef,
+  Ben Ish Hai, Chabad, taharat hamishpacha, Jewish calendar, Hebrew dates,
+  parasha, fast days, or any Hebrew-language question about Jewish life.
+  Also trigger on "is X kosher?", "when is Y holiday?",
+  "how do Sephardim / Ashkenazim / Chabad do...", or "what does Judaism say about...".
+---
+
+# Torah Q&A Skill
+
+Route Torah and halachah questions through `torah_ask` — a local Ollama-backed
+assistant. Supports Hebrew and English with six halachic modes.
+
+## Tools
+
+| Tool | When |
+|------|------|
+| `torah_ask` | Any Torah, halachah, or Jewish lifestyle question |
+| `torah_modes` | User is unsure which tradition / mode to use |
+| `torah_health` | Diagnose connection issues with the Ollama backend |
+
+## Mode Selection
+
+| User context | Mode |
+|---|---|
+| No tradition specified / general study | Torah |
+| Sephardi, Israeli, Rav Ovadia | Yalkut Yosef |
+| Baghdadi / Iraqi family | Ben Ish Hai |
+| Chabad / Lubavitch / Tanya | Chabad |
+| Kashrut (ingredients, kitchen, hechsher) | Kashrut |
+| Comparing traditions | Minhagim |
+
+## Workflow
+
+1. Identify the question type and user's tradition (if mentioned)
+2. Select the mode (default: Torah)
+3. Call `torah_ask` — preserve the original language (Hebrew or English)
+4. Present the answer directly — do not rephrase Torah rulings
+5. If the question involves a practical ruling, the tool already appends a "consult your rav" note
+
+## Error Handling
+
+If `torah_ask` errors with a timeout or connection issue:
+- Run `torah_health` to diagnose
+- If model not loaded, suggest: `ollama pull <model>`
+- If server unreachable, suggest: `ollama serve`
+- Retry once after ~10 seconds if the error mentions "loading"
+
+## Boundaries
+
+- Only Torah/halachah/Jewish topics — use standard capabilities for other questions
+- Do not invent halachic rulings — always route through `torah_ask`
+- Do not blend traditions in the same answer
+- Read-only — no confirmations needed

--- a/plugins/ollama-torah-mcp/src/index.ts
+++ b/plugins/ollama-torah-mcp/src/index.ts
@@ -1,0 +1,281 @@
+/**
+ * ollama-torah-mcp — Generic Torah Q&A MCP server backed by any Ollama instance.
+ *
+ * Works with any Ollama-compatible endpoint. No vendor lock-in, no third-party
+ * AI APIs. Bring your own model and endpoint.
+ *
+ * Env vars:
+ *   OLLAMA_URL     — Base URL of the Ollama server (e.g. http://localhost:11434)
+ *   OLLAMA_MODEL   — Model tag to use (default: qwen2.5:0.5b-instruct)
+ *   REQUEST_TIMEOUT — Request timeout in ms (default: 30000)
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+const OLLAMA_URL = (process.env.OLLAMA_URL || "http://localhost:11434").replace(
+  /\/$/,
+  ""
+);
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || "qwen2.5:0.5b-instruct";
+const REQUEST_TIMEOUT = Number(process.env.REQUEST_TIMEOUT) || 30_000;
+
+// ── Halachic modes ──────────────────────────────────────────────────────────
+
+const MODES = [
+  "Torah",
+  "Yalkut Yosef",
+  "Ben Ish Hai",
+  "Chabad",
+  "Kashrut",
+  "Minhagim",
+] as const;
+
+type Mode = (typeof MODES)[number];
+
+const MODE_SYSTEM: Record<Mode, string> = {
+  Torah:
+    "You are a Torah study assistant. Focus on Chumash, Gemara, Rambam, and classical Torah commentary. " +
+    "Answer in the same language the user writes (Hebrew or English). " +
+    "Keep replies respectful, family-safe, and halachah-conscious. " +
+    "For practical halachic rulings, recommend consulting a local rav.",
+  "Yalkut Yosef":
+    "You are a halachah assistant following Rav Ovadia Yosef's rulings and the Yalkut Yosef. " +
+    "Prioritize Sephardi practice. Distinguish lechatchilah and bediavad when relevant. " +
+    "Answer in the same language the user writes. Recommend consulting a local rav for practical rulings.",
+  "Ben Ish Hai":
+    "You are a halachah assistant following the Ben Ish Hai and Baghdadi/Iraqi Sephardi minhagim. " +
+    "Note when this differs from later Sephardi practice. " +
+    "Answer in the same language the user writes. Recommend consulting a local rav for practical rulings.",
+  Chabad:
+    "You are a halachah assistant following Chabad-Lubavitch custom and the Alter Rebbe's rulings. " +
+    "Separate Chabad minhag from general halachah when relevant. " +
+    "Answer in the same language the user writes. Recommend consulting a local rav for practical rulings.",
+  Kashrut:
+    "You are a kashrut assistant. Focus on kashrut laws, ingredients, hechsherim, " +
+    "milchig/fleishig separation, pareve handling, and community differences. " +
+    "Answer in the same language the user writes. Recommend consulting a local rav for practical rulings.",
+  Minhagim:
+    "You are a Jewish customs assistant. Explain which answer follows which tradition, " +
+    "compare Yalkut Yosef, Ben Ish Hai, Chabad, and general practice when needed. " +
+    "Do not blend customs together. Answer in the same language the user writes.",
+};
+
+// ── Ollama client ───────────────────────────────────────────────────────────
+
+interface OllamaMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+interface OllamaChatResponse {
+  message?: { content?: string };
+  response?: string;
+  error?: string;
+}
+
+async function ollamaChat(
+  messages: OllamaMessage[],
+  model?: string
+): Promise<string> {
+  const url = `${OLLAMA_URL}/api/chat`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: model || OLLAMA_MODEL,
+      messages,
+      stream: false,
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Ollama returned HTTP ${res.status}. ` +
+        `Check OLLAMA_URL (${OLLAMA_URL}) and OLLAMA_MODEL (${OLLAMA_MODEL}). ` +
+        body.slice(0, 200)
+    );
+  }
+
+  const data: OllamaChatResponse = await res.json();
+
+  if (data.error) {
+    throw new Error(`Ollama error: ${data.error}`);
+  }
+
+  const text = data.message?.content || data.response || "";
+  if (!text.trim()) {
+    throw new Error(
+      "Ollama returned an empty response. The model may still be loading — retry in a few seconds."
+    );
+  }
+  return text.trim();
+}
+
+// ── MCP Server ──────────────────────────────────────────────────────────────
+
+const server = new McpServer({
+  name: "ollama-torah-mcp",
+  version: "1.0.0",
+});
+
+// Tool: torah_ask — primary Q&A
+server.tool(
+  "torah_ask",
+  "Ask a Torah, halachah, or Jewish studies question. Routes to a local Ollama model. " +
+    "Supports Hebrew and English. Choose a halachic mode to tailor the tradition.",
+  {
+    question: z
+      .string()
+      .min(1)
+      .describe("The question in Hebrew or English"),
+    mode: z
+      .enum(MODES)
+      .default("Torah")
+      .describe(
+        "Halachic tradition: Torah (general), Yalkut Yosef (Sephardi), " +
+          "Ben Ish Hai (Baghdadi), Chabad, Kashrut (food laws), Minhagim (customs)"
+      ),
+    context: z
+      .string()
+      .optional()
+      .describe(
+        "Optional prior conversation context to include (e.g. previous Q&A)"
+      ),
+  },
+  async ({ question, mode, context }) => {
+    try {
+      const messages: OllamaMessage[] = [
+        { role: "system", content: MODE_SYSTEM[mode] },
+      ];
+      if (context) {
+        messages.push({ role: "user", content: context });
+        messages.push({
+          role: "assistant",
+          content: "(continuing the conversation)",
+        });
+      }
+      messages.push({ role: "user", content: question });
+
+      const answer = await ollamaChat(messages);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `**[${mode}]**\n\n${answer}\n\n---\n*For practical halachic decisions, consult your local rav.*`,
+          },
+        ],
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `**Error:** ${msg}\n\nTroubleshooting:\n- Is Ollama running at \`${OLLAMA_URL}\`?\n- Is the model \`${OLLAMA_MODEL}\` pulled? Run: \`ollama pull ${OLLAMA_MODEL}\`\n- Try increasing REQUEST_TIMEOUT (currently ${REQUEST_TIMEOUT}ms)`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Tool: torah_modes — list available traditions
+server.tool(
+  "torah_modes",
+  "List available halachic modes (traditions) with descriptions. " +
+    "Use when the user is unsure which tradition to choose.",
+  {},
+  async () => ({
+    content: [
+      {
+        type: "text" as const,
+        text: [
+          "## Available Halachic Modes\n",
+          "| Mode | Tradition | Best For |",
+          "|------|-----------|----------|",
+          "| Torah | General / multi-tradition | Chumash, Gemara, Rambam, hashkafah, study, kids homework |",
+          "| Yalkut Yosef | Sephardi (Rav Ovadia Yosef) | Practical Sephardi halachah, Israeli Sephardi practice |",
+          "| Ben Ish Hai | Baghdadi / Iraqi Sephardi | Baghdadi minhagim, Iraqi community customs |",
+          "| Chabad | Chabad-Lubavitch | Chabad minhagim, Alter Rebbe rulings, Tanya |",
+          "| Kashrut | Kashrut focus | Kitchen questions, ingredients, hechsherim, milchig/fleishig |",
+          "| Minhagim | Customs & differences | Comparing traditions, holiday customs, community variations |",
+        ].join("\n"),
+      },
+    ],
+  })
+);
+
+// Tool: torah_health — connectivity check
+server.tool(
+  "torah_health",
+  "Check if the Ollama backend is reachable and the model is loaded. " +
+    "Use to diagnose connection issues before asking questions.",
+  {},
+  async () => {
+    try {
+      const start = Date.now();
+      const res = await fetch(`${OLLAMA_URL}/api/tags`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      const elapsed = Date.now() - start;
+
+      if (!res.ok) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `**Unhealthy** — Ollama returned HTTP ${res.status} (${elapsed}ms)\nURL: ${OLLAMA_URL}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const data = await res.json();
+      const models = (data.models || []).map(
+        (m: { name: string }) => m.name
+      );
+      const hasModel = models.some(
+        (n: string) =>
+          n === OLLAMA_MODEL || n.startsWith(OLLAMA_MODEL.split(":")[0])
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: [
+              `**${hasModel ? "Healthy" : "Warning"}** (${elapsed}ms)`,
+              `- URL: \`${OLLAMA_URL}\``,
+              `- Target model: \`${OLLAMA_MODEL}\` ${hasModel ? "— loaded" : "— **not found**, run `ollama pull " + OLLAMA_MODEL + "`"}`,
+              `- Available models: ${models.length ? models.join(", ") : "(none)"}`,
+            ].join("\n"),
+          },
+        ],
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `**Unreachable** — ${msg}\n\nIs Ollama running? Start with: \`ollama serve\`\nExpected URL: \`${OLLAMA_URL}\``,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── Start ────────────────────────────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/plugins/ollama-torah-mcp/tsconfig.json
+++ b/plugins/ollama-torah-mcp/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/scripts/package-plugin.sh
+++ b/scripts/package-plugin.sh
@@ -47,6 +47,7 @@ fi
 
 # ── Prepare output dir ──────────────────────────────
 mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 OUTPUT_FILE="$OUTPUT_DIR/$PLUGIN_NAME-$VERSION.plugin"
 
 # Remove any existing build for this version
@@ -56,7 +57,7 @@ rm -f "$OUTPUT_FILE"
 # We zip the CONTENTS of .claude-plugin/ so the archive root
 # contains plugin.json, skills/, agents/, etc. directly.
 cd "$CLAUDE_PLUGIN_DIR"
-zip -r "$OLDPWD/$OUTPUT_FILE" . \
+zip -r "$OUTPUT_FILE" . \
   --exclude "*.DS_Store" \
   --exclude "__pycache__/*" \
   --exclude "*.pyc" \


### PR DESCRIPTION
## Summary
- Adds **ollama-torah-mcp** — a generic, self-hosted Torah Q&A MCP server powered by any Ollama instance
- 3 tools: `torah_ask`, `torah_modes`, `torah_health`
- 6 halachic modes: Torah, Yalkut Yosef, Ben Ish Hai, Chabad, Kashrut, Minhagim
- Bilingual Hebrew/English, SOSA Level 2 compliant
- No hardcoded URLs — fully configurable via env vars
- Includes QA test plan (13 test cases)
- **Also fixes** `scripts/package-plugin.sh` absolute path bug in zip output

## Test plan
- [ ] CI: structure validation, plugin.json schema, SKILL.md quality, dry-run build
- [ ] SOSA compliance check passes
- [ ] Manual: `torah_health` against a running Ollama instance
- [ ] Manual: `torah_ask` with Hebrew and English questions across all 6 modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)