### PR TITLE
ci(release): fix plugin release push race + harden rollout order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,38 +92,19 @@ jobs:
           echo "✓ Plugin structure valid"
 
       # ── Bump patch version ─────────────────────────────────────
+      # Modifies plugin.json in place. NOT committed yet — we package and
+      # generate notes against the uncommitted bump first so any failure
+      # there can be discarded cleanly without leaving a bump commit on
+      # main that has no matching tag or .plugin artifact.
       - name: Bump version
         id: bump
         run: |
           chmod +x scripts/bump-version.sh
           bash scripts/bump-version.sh ${{ matrix.plugin }} patch
 
-      # ── Commit version bump ────────────────────────────────────
-      # Even with the job-level concurrency gate, a human push to main
-      # could land between our checkout and our push. Rebase-retry keeps
-      # the release robust instead of failing the whole pipeline.
-      - name: Commit version bump
-        run: |
-          PLUGIN="${{ matrix.plugin }}"
-          NEW_VERSION="${{ steps.bump.outputs.new_version }}"
-          git add "plugins/$PLUGIN/.claude-plugin/plugin.json"
-          git commit -m "chore(release): bump $PLUGIN to v$NEW_VERSION [skip ci]"
-
-          for attempt in 1 2 3 4 5; do
-            if git push; then
-              echo "✓ push succeeded on attempt $attempt"
-              break
-            fi
-            echo "push attempt $attempt rejected — rebasing onto latest main and retrying..."
-            git pull --rebase origin main
-            if [[ $attempt -eq 5 ]]; then
-              echo "::error::git push failed after 5 attempts"
-              exit 1
-            fi
-            sleep $((attempt * 2))
-          done
-
       # ── Package the plugin ─────────────────────────────────────
+      # Runs BEFORE the git push so a packaging failure doesn't leave
+      # a version bump on main with no matching release.
       - name: Package plugin
         id: package
         run: |
@@ -166,7 +147,36 @@ jobs:
           } > /tmp/release_notes.md
           echo "notes_file=/tmp/release_notes.md" >> $GITHUB_OUTPUT
 
+      # ── Commit version bump ────────────────────────────────────
+      # Runs AFTER packaging + notes succeed, so a failure up to this
+      # point leaves no commit on main (the dirty plugin.json gets
+      # discarded with the runner). Even with the job-level concurrency
+      # gate, a human push to main could land between our checkout and
+      # our push; rebase-retry keeps the release robust.
+      - name: Commit version bump
+        run: |
+          PLUGIN="${{ matrix.plugin }}"
+          NEW_VERSION="${{ steps.bump.outputs.new_version }}"
+          git add "plugins/$PLUGIN/.claude-plugin/plugin.json"
+          git commit -m "chore(release): bump $PLUGIN to v$NEW_VERSION [skip ci]"
+
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              echo "✓ push succeeded on attempt $attempt"
+              break
+            fi
+            echo "push attempt $attempt rejected — rebasing onto latest main and retrying..."
+            git pull --rebase origin main
+            if [[ $attempt -eq 5 ]]; then
+              echo "::error::git push failed after 5 attempts"
+              exit 1
+            fi
+            sleep $((attempt * 2))
+          done
+
       # ── Create GitHub Release ──────────────────────────────────
+      # Last step that mutates remote state. Creates the tag on the bump
+      # commit we just pushed and uploads the .plugin artifact.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -179,10 +189,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Summary
+      - name: Success summary
+        if: success()
         run: |
           echo "### ✅ Released ${{ matrix.plugin }} v${{ steps.bump.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Previous version:** ${{ steps.bump.outputs.old_version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **New version:** ${{ steps.bump.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Package:** \`${{ matrix.plugin }}-${{ steps.bump.outputs.new_version }}.plugin\`" >> $GITHUB_STEP_SUMMARY
+
+      # Prints a ready-to-paste recovery command when any prior step failed.
+      # Cuts MTTR and makes the failure mode self-documenting on every run.
+      - name: Failure summary
+        if: failure()
+        run: |
+          PLUGIN="${{ matrix.plugin }}"
+          NEW_VERSION="${{ steps.bump.outputs.new_version }}"
+          echo "### ❌ Release failed for $PLUGIN" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Retrigger the release:** push any trivial change inside \`plugins/$PLUGIN/\`." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "git checkout main && git pull" >> $GITHUB_STEP_SUMMARY
+          echo "echo '' >> plugins/$PLUGIN/README.md" >> $GITHUB_STEP_SUMMARY
+          echo "git commit -am 'chore: retrigger release for $PLUGIN'" >> $GITHUB_STEP_SUMMARY
+          echo "git push origin main" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [[ -n "$NEW_VERSION" ]]; then
+            echo "**If the bump commit landed but the tag/release didn't:**" >> $GITHUB_STEP_SUMMARY
+            echo '```bash' >> $GITHUB_STEP_SUMMARY
+            echo "git tag $PLUGIN-v$NEW_VERSION" >> $GITHUB_STEP_SUMMARY
+            echo "git push origin $PLUGIN-v$NEW_VERSION" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect
     if: needs.detect.outputs.has_changes == 'true'
+    # Serialize all plugin releases against main so concurrent matrix cells
+    # (and back-to-back workflow runs) don't race on `git push` of the
+    # version-bump commit. Without this, the first job wins and the rest
+    # fail with non-fast-forward. See incident 2026-04-19 (run 24620806243).
+    concurrency:
+      group: plugin-release-main
+      cancel-in-progress: false
     strategy:
       matrix:
         plugin: ${{ fromJson(needs.detect.outputs.plugins) }}
       fail-fast: false  # release other plugins even if one fails
+      max-parallel: 1   # defense-in-depth: serialize within a single run too
 
     steps:
       - uses: actions/checkout@v4
@@ -91,13 +99,29 @@ jobs:
           bash scripts/bump-version.sh ${{ matrix.plugin }} patch
 
       # ── Commit version bump ────────────────────────────────────
+      # Even with the job-level concurrency gate, a human push to main
+      # could land between our checkout and our push. Rebase-retry keeps
+      # the release robust instead of failing the whole pipeline.
       - name: Commit version bump
         run: |
           PLUGIN="${{ matrix.plugin }}"
           NEW_VERSION="${{ steps.bump.outputs.new_version }}"
           git add "plugins/$PLUGIN/.claude-plugin/plugin.json"
           git commit -m "chore(release): bump $PLUGIN to v$NEW_VERSION [skip ci]"
-          git push
+
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              echo "✓ push succeeded on attempt $attempt"
+              break
+            fi
+            echo "push attempt $attempt rejected — rebasing onto latest main and retrying..."
+            git pull --rebase origin main
+            if [[ $attempt -eq 5 ]]; then
+              echo "::error::git push failed after 5 attempts"
+              exit 1
+            fi
+            sleep $((attempt * 2))
+          done
 
       # ── Package the plugin ─────────────────────────────────────
       - name: Package plugin


### PR DESCRIPTION
## Summary

Two related fixes to `Plugin Release` workflow, found via incident [run 24620806243](https://github.com/MSApps-Mobile/Claude-plugins/actions/runs/24620806243):

1. **Serialize releases** — concurrency group + `max-parallel: 1` + rebase-retry on `git push`. Kills the parallel-push race condition that took out `mac-disk-cleaner` and `cowork-session-fixer` when 3 plugins changed in `fa3a0cd`.
2. **Reorder steps + fail-loud summary** — package + notes now run BEFORE the push, so a failure after the bump can't leave main with a version-bumped `plugin.json` but no tag or `.plugin` artifact. An `if: failure()` summary prints the recovery command to every failed run.

## Root cause of run 24620806243

All 3 matrix cells (`cowork-mem`, `mac-disk-cleaner`, `cowork-session-fixer`) checked out the same SHA, each bumped its own `plugin.json`, each tried to `git push`. First one wins; the others get non-fast-forward rejection → exit 1 → no build, no release. `cowork-mem` shipped ✅, the other two didn't.

## Fix, defense-in-depth

**Commit 1 — serialize:**
- Job-level `concurrency: { group: plugin-release-main, cancel-in-progress: false }` serializes across matrix cells AND back-to-back workflow runs.
- `strategy.max-parallel: 1` serializes within a single run.
- Rebase-retry loop on the push step (5 attempts, linear backoff) self-heals if a human push lands between our checkout and our push.

**Commit 2 — reorder + observability:**
- New step order: `bump → package → notes → commit+push → release`. Failures before the push leave the runner with a dirty tree that gets discarded. Only the final `softprops/action-gh-release@v2` step can cause state drift, which is a much tighter blast radius.
- `if: failure()` summary prints a ready-to-paste retrigger command and — if the bump already pushed — the manual tag/release fallback.

## Recovery for the broken run (after this merges)

```bash
git checkout main && git pull
echo "" >> plugins/mac-disk-cleaner/README.md
echo "" >> plugins/cowork-session-fixer/README.md
git commit -am "chore: retrigger release for mac-disk-cleaner and cowork-session-fixer"
git push origin main
```

Neither plugin has ever been tagged by this workflow before (no `*-v*` tags exist). After retrigger they'll debut at `mac-disk-cleaner-v0.2.1` and `cowork-session-fixer-v1.1.1`. If you'd rather different starting versions, manually edit each `plugin.json` before pushing the retrigger.

## Test plan

- [ ] PR passes existing `validate-pr.yml` + `sosa-lint.yml`
- [ ] After merge, intentionally touch 2+ plugins in one commit — confirm matrix cells run serially (second cell starts only after first completes)
- [ ] Confirm `softprops/action-gh-release@v2` still tags + uploads the `.plugin` correctly
- [ ] Force a failure (e.g., by introducing a bad bump-version.sh arg on a throwaway branch) and confirm the `Failure summary` step runs and prints usable commands
