### PR TITLE
feat: add agents-md-optimizer plugin

### DIFF
--- a/plugins/agents-md-optimizer/.claude-plugin/plugin.json
+++ b/plugins/agents-md-optimizer/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "agents-md-optimizer",
+  "version": "1.0.0",
+  "description": "Audit bloated agent-instruction files (CLAUDE.md, AGENTS.md, and their variants) and rewrite them lean, or author a new one from scratch following the 200-line recipe-book principle. Detects anti-patterns like embedded API docs, negative rules, tutorials, and preemptive file preloads.",
+  "author": {
+    "name": "MSApps"
+  },
+  "repository": "https://github.com/MSApps-Mobile/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "claude-md",
+    "agents-md",
+    "context-optimization",
+    "token-efficiency",
+    "agent-instructions",
+    "prompt-engineering",
+    "msapps"
+  ],
+  "topics": [
+    "sosa-agents"
+  ],
+  "sosa": {
+    "compliant": true,
+    "level": 2,
+    "methodology": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/SOSA.md"
+  },
+  "privacy_policy": "https://opsagents.agency/privacy",
+  "terms_of_service": "https://opsagents.agency/terms"
+}

--- a/plugins/agents-md-optimizer/CLAUDE.md
+++ b/plugins/agents-md-optimizer/CLAUDE.md
@@ -1,0 +1,16 @@
+# agents-md-optimizer
+
+Plugin that audits and rewrites bloated `CLAUDE.md` / `AGENTS.md` files, or authors new ones lean from scratch.
+
+## Skill
+
+- `skills/agents-md-optimizer/SKILL.md` — core skill with audit and author modes
+- `skills/agents-md-optimizer/references/template.md` — lean CLAUDE.md skeleton
+- `skills/agents-md-optimizer/references/anti-patterns.md` — bloat pattern catalog
+- `skills/agents-md-optimizer/scripts/audit.py` — quantitative audit script
+
+## Quick reference
+
+- **Target file size:** ≤200 lines, ≤1600 tokens
+- **Anti-patterns:** negative rules, embedded docs, tutorials, preemptive preloads, dated state, personal prefs
+- **Extraction targets:** `docs/` for reference material, `~/.claude/CLAUDE.md` for personal prefs, `CLAUDE.local.md` for ephemeral state, Skills for runnable procedures

--- a/plugins/agents-md-optimizer/README.md
+++ b/plugins/agents-md-optimizer/README.md
@@ -1,0 +1,75 @@
+# agents-md-optimizer
+
+Audit bloated agent-instruction files (`CLAUDE.md`, `AGENTS.md`, and their local/user-level variants) and rewrite them lean — or author a new one from scratch following the 200-line "recipe book" principle.
+
+## What it does
+
+`CLAUDE.md` is loaded into every Claude session. Every line is a recurring tax on the context window, paid before any real work starts, across every session, forever. Most files drift into bloat: embedded API docs, step-by-step tutorials, hoarded historical state, stacked negative "don't do X" rules.
+
+This plugin provides two modes:
+
+| Mode | When to use |
+|------|-------------|
+| **Audit** | You have an existing file that's grown too large or has anti-patterns |
+| **Author** | You want a lean `CLAUDE.md` for a new or undocumented project |
+
+## Skills
+
+### `agents-md-optimizer`
+
+The core skill. Detects the right mode from context and runs accordingly.
+
+**Audit mode** — reads the target file, runs `scripts/audit.py` for a quantitative report (line count, token estimate, anti-patterns with line numbers), classifies every section as keep/extract/delete, and produces:
+1. The full rewritten file, lean and ready to drop in
+2. An extraction plan mapping every removed section to its correct destination
+
+**Author mode** — interviews the user (project identity, stack, house rules, output prefs, boundaries) and writes a lean file using `references/template.md`.
+
+## Trigger phrases
+
+- "My CLAUDE.md is too big"
+- "Trim / audit my CLAUDE.md"
+- "Write a CLAUDE.md for my new project"
+- "Optimize my agent instructions"
+- "AGENTS.md is bloated"
+- Any `CLAUDE.md` or `AGENTS.md` in context that is >200 lines or contains known anti-patterns
+
+## The four-layer hierarchy
+
+Understanding where things belong is the core of this skill:
+
+1. **Enterprise policy** — org-wide, set by admins
+2. **`./CLAUDE.md`** — project-level, committed to the repo, shared with every collaborator
+3. **`~/.claude/CLAUDE.md`** — user-level, personal defaults across every project
+4. **`./CLAUDE.local.md`** — project-local, gitignored, personal notes about this specific repo
+
+## Anti-patterns detected
+
+| Pattern | Fix |
+|---------|-----|
+| Negative rules stacked | Flip to positive directives |
+| Embedded reference docs | Move to `docs/`, add a pointer |
+| Step-by-step tutorials | Extract to a script or Skill |
+| Preemptive file preloads | Delete — Claude reads on demand |
+| Ephemeral / dated state | Move to `CLAUDE.local.md` |
+| Personal preferences | Move to `~/.claude/CLAUDE.md` |
+| Duplicated skill content | Delete — skill already covers it |
+| General knowledge re-statements | Delete |
+
+## Reference files
+
+- `skills/agents-md-optimizer/references/template.md` — lean `CLAUDE.md` skeleton
+- `skills/agents-md-optimizer/references/anti-patterns.md` — catalog of bloat patterns with before/after rewrites
+- `skills/agents-md-optimizer/scripts/audit.py` — quantitative audit script
+
+## Script usage
+
+```bash
+python3 skills/agents-md-optimizer/scripts/audit.py path/to/CLAUDE.md
+python3 skills/agents-md-optimizer/scripts/audit.py path/to/CLAUDE.md --json
+python3 skills/agents-md-optimizer/scripts/audit.py path/to/CLAUDE.md --strict
+```
+
+## Install
+
+Install via the Cowork plugin system or copy `skills/agents-md-optimizer/` into your `.claude/skills/` directory.

--- a/plugins/agents-md-optimizer/skills/agents-md-optimizer/SKILL.md
+++ b/plugins/agents-md-optimizer/skills/agents-md-optimizer/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: agents-md-optimizer
+description: Audit bloated agent-instruction files (CLAUDE.md, AGENTS.md, and their local/user-level variants) and rewrite them lean, or author a new one from scratch following the 200-line "recipe book" principle. Use this skill whenever the user mentions CLAUDE.md, AGENTS.md, agent instruction file, project memory file, context file, token budget, context bloat, "my CLAUDE.md is too big", trimming CLAUDE.md, auditing AGENTS.md, writing AGENTS.md for a new project, or any discussion of what belongs in the agent-instruction-file hierarchy (enterprise, project, user-level, project-local). Also trigger when such a file is shown in context and is visibly long (over 200 lines) or contains anti-patterns like embedded API docs, negative "Don't do X" rules, step-by-step tutorials, or preemptive file-preload instructions — even if the user doesn't explicitly ask for optimization, proactively offer to use it.
+---
+
+# agents-md-optimizer
+
+## What this skill does
+
+`CLAUDE.md` is loaded into every Claude session for the project it belongs to. That means every line is a recurring tax on the context window — paid before any real work starts, across every session, forever. Most `CLAUDE.md` files drift into bloat: people copy-paste API docs, write step-by-step tutorials, hoard historical state, stack negative "don't do X" rules. The result is a ~2,000-token baseline cost that degrades focus and wastes budget.
+
+The fix is to treat `CLAUDE.md` like a focused recipe book: essential guidance only, everything else extracted to a location that loads on-demand. This skill does two things:
+
+1. **Audit mode** — read an existing `CLAUDE.md`, diagnose what's bloat, and produce a slimmed rewrite plus an extraction plan (what moves where).
+2. **Author mode** — interview about a new project and write a lean `CLAUDE.md` from scratch using the template.
+
+## When to pick a mode
+
+Detect mode from input:
+
+- **The user points at an existing file, or one is visible in context** → audit mode.
+- **The user wants a fresh `CLAUDE.md` for a new or undocumented project** → author mode.
+- **Both** (they showed a file but also want a rewrite philosophy applied to a second project) → run audit first, carry the principles into the author pass.
+
+If it's ambiguous, ask one clarifying question: "Are we trimming an existing one, or writing a new one?"
+
+## The four-layer hierarchy — know where things actually belong
+
+Every recommendation in this skill depends on understanding that `CLAUDE.md` isn't monolithic. Claude loads four layers in precedence order:
+
+1. **Enterprise policy** — organization-wide, set by admins.
+2. **`./CLAUDE.md`** — project-level, committed to the repo. This is what most people mean by "CLAUDE.md." Shared with every collaborator.
+3. **`~/.claude/CLAUDE.md`** — user-level, personal defaults that apply across every project. Communication prefs, your own account info, your shell aliases.
+4. **`./CLAUDE.local.md`** — project-local overrides, gitignored. Personal notes about this specific repo that shouldn't be shared with collaborators.
+
+When you find content that doesn't belong in the project `CLAUDE.md`, the right extraction target is usually one of these other layers, not just "delete it."
+
+**Rule of thumb for extraction:**
+- Personal communication style, cross-project aliases, "I prefer X" → `~/.claude/CLAUDE.md`
+- Ephemeral state (gcloud auth status, current sprint number, active branch) → `./CLAUDE.local.md`
+- Team-shared conventions, tech stack, boundaries → stays in `./CLAUDE.md`
+- Deep reference material (API docs, architecture deep-dives, runbooks) → `docs/`, referenced by path
+- Repeatable multi-step workflows → extract into a Skill
+
+## What belongs in project CLAUDE.md (the lean template)
+
+A good project `CLAUDE.md` fits on roughly one screen (~200 lines max). See `references/template.md` for the full skeleton. The essential sections:
+
+- **Project identity** — 2–3 sentences: what this codebase does and who it's for.
+- **Tech stack** — language, framework, key APIs, deploy target, testing tool. One line each.
+- **Code conventions** — the 3–7 house rules a new contributor would genuinely need on day one. Written as positive directives, not prohibitions.
+- **Output preferences** — how Claude should present solutions in this repo (diff format, code-block length, explanation style).
+- **Boundaries** — hard stops: files that should never be modified, secrets that should never be committed, commands that must run before finishing (lint/typecheck/test).
+- **Quick reference** — pointers to main entry files, test locations, and `docs/` for anything deeper.
+
+Everything else is bloat. If it's not needed on *every* interaction with this repo, it belongs somewhere that loads on demand.
+
+## Audit mode — how to run it
+
+### Step 1: Read the file and quantify
+
+Read the target `CLAUDE.md`. Run `scripts/audit.py <path>` to get a structured report:
+
+```bash
+python3 scripts/audit.py <path-to-CLAUDE.md>
+```
+
+The script reports: line count, estimated token count (~4 chars/token heuristic), detected anti-patterns with line numbers, and section-by-section classification (essential / extract / delete).
+
+If the file is already ≤200 lines and the audit finds no anti-patterns, tell the user it's already lean and stop. Don't invent problems.
+
+### Step 2: Classify every section
+
+For each section of the file, decide: **keep**, **extract**, or **delete**.
+
+- **Keep** if it's essential project identity, a convention that affects every interaction, an output preference, or a hard boundary.
+- **Extract** if it's useful but specific to a subset of interactions. Name the destination explicitly (`docs/hooks.md`, `~/.claude/CLAUDE.md`, `CLAUDE.local.md`, a new skill).
+- **Delete** if it's obsolete, duplicated elsewhere (e.g., already in an installed skill), or a "just in case" note that's never actually referenced.
+
+### Step 3: Apply the anti-pattern fixes
+
+See `references/anti-patterns.md` for the full list and rewrite patterns. Summary:
+
+- **Negative rules → positive rules.** "Don't use `var`" becomes "Use `const`/`let`." Positive instructions compile to shorter mental models and avoid reinforcing the thing you're trying to prevent.
+- **Embedded reference docs → links.** A 200-line API schema inside `CLAUDE.md` becomes `See docs/api-reference.md for endpoint schemas.`
+- **Tutorials / step-by-step procedures → Skills.** If it reads like a runbook, it belongs in `.claude/skills/<name>/SKILL.md` where it loads only when relevant.
+- **Preemptive file preloads → removed.** Instructions like "Read `src/config.ts` at session start" are almost always wasteful; Claude can read files on demand when the task requires them.
+- **Historical state / status tables → `CLAUDE.local.md`.** Anything dated (gcloud auth status from 3 weeks ago, "current sprint goal") is ephemeral and doesn't belong in a shared file.
+
+### Step 4: Produce two outputs
+
+1. **The rewritten `CLAUDE.md`** — the full replacement file, lean and ready to drop in.
+2. **The extraction plan** — a clear list: "Lines X–Y (topic) → destination Z, because …" so the user can act on the extractions (create those docs, move content to user-level, etc.).
+
+Show the before/after stats at the top of the plan: original line count, new line count, estimated token delta, percent reduction.
+
+Do not silently lose content. Every deleted or moved section must appear somewhere in the extraction plan, so the user can audit the move.
+
+## Author mode — how to run it
+
+### Step 1: Interview
+
+Ask the user about:
+- **Identity**: What does the codebase do? (2–3 sentence answer)
+- **Stack**: Language, framework, APIs, deploy target, test tool.
+- **House rules**: Top 3–5 conventions new contributors need to know.
+- **Output prefs**: Diff style, explanation length, any formatting requests.
+- **Boundaries**: Files never to touch, secrets, required pre-finish checks.
+- **References**: Where do architecture docs live? Canonical knowledge store (Notion, Confluence, `docs/`)?
+
+Batch these questions — two or three at a time, not one by one. Don't ask about every conceivable section; the template has defaults for missing info.
+
+### Step 2: Write the file
+
+Fill in `references/template.md`. Keep each section tight. If a section has nothing real to put in it, delete the section rather than pad with "TBD" — missing sections are information, padding is noise.
+
+### Step 3: Verify
+
+Run `scripts/audit.py` on the result. It should pass all checks. If it doesn't (e.g., you accidentally included a 40-line JSON example), fix before delivering.
+
+## Output format
+
+Whichever mode, the final output structure is:
+
+```
+## Stats
+[before/after line and token counts, percent reduction if auditing]
+
+## CLAUDE.md
+` ` `md
+[the full lean file, ready to save]
+` ` `
+
+## Extraction plan  (audit mode only)
+- Lines X–Y [topic] → [destination] — [one-line why]
+- …
+
+## Next steps
+[concrete actions: create docs/foo.md with content X, add Y to ~/.claude/CLAUDE.md, etc.]
+```
+
+## Principle of lack of surprise
+
+This skill only rewrites `CLAUDE.md`-family files (CLAUDE.md, AGENTS.md, CLAUDE.local.md). Never modify source code, configs, or secrets while doing this. Never delete the original until the user confirms the rewrite works — write the new file alongside the old one (e.g., `CLAUDE.md.new`) or show the diff and let them apply it.
+
+If the audit would extract content to new files the user hasn't seen yet (a new `docs/hooks.md`, a new Skill), draft those too but clearly mark them as "proposed" — don't auto-create a web of new files without consent.
+
+## Reference files
+
+- `references/template.md` — The lean `CLAUDE.md` skeleton with all essential sections and inline guidance. Read this before writing in author mode.
+- `references/anti-patterns.md` — The catalog of common bloat patterns with before/after rewrite examples. Read this before auditing.
+
+## Script
+
+- `scripts/audit.py` — Runs a quantitative audit: line count, token estimate, anti-pattern detection by regex, section classification. Use it at the start of audit mode and again as a final check on any rewrite (author or audit).

--- a/plugins/agents-md-optimizer/skills/agents-md-optimizer/references/anti-patterns.md
+++ b/plugins/agents-md-optimizer/skills/agents-md-optimizer/references/anti-patterns.md
@@ -1,0 +1,116 @@
+# CLAUDE.md anti-patterns and how to fix them
+
+Each pattern below is something that commonly bloats `CLAUDE.md`. For each one: how to spot it, why it's a problem, and the rewrite.
+
+## 1. Negative rules stacked on negative rules
+
+**Spot it:** Lines starting with "Don't", "Never", "Avoid", "Do not", especially stacked 3+ in a row.
+
+**Why it's a problem:** Negative rules force the reader (human or model) to hold the forbidden concept in mind while simultaneously trying to suppress it. They also tend to multiply — every new mistake adds a new "don't" rather than revising the positive rule.
+
+**Rewrite:** Flip to a positive directive that makes the forbidden thing unnecessary.
+
+| Before | After |
+|---|---|
+| `Don't use var. Don't use let in global scope. Don't mutate globals.` | `Use const at module scope. Use let only inside the narrowest block that needs reassignment.` |
+| `Never hardcode API keys. Never put credentials in code.` | `Read credentials from environment variables; never commit .env files.` |
+| `Don't write inline styles. Don't use CSS-in-JS at runtime.` | `Style with Tailwind utility classes; extend via tailwind.config.ts when needed.` |
+
+**Exception:** Genuine hard stops with no positive rephrasing ("Never modify files under `vendor/`") belong in the Boundaries section and stay negative — because that's their actual semantic: a prohibition, not a preference.
+
+## 2. Embedded reference docs
+
+**Spot it:** Long code blocks, JSON schemas, API tables, type definitions, HTTP endpoint lists. Usually 20+ contiguous lines.
+
+**Why it's a problem:** Reference docs are consulted rarely. `CLAUDE.md` loads every session. A 200-line schema in `CLAUDE.md` is 200 lines spent on context most tasks don't need.
+
+**Rewrite:** Move to `docs/` and replace with a pointer.
+
+**Before:**
+```markdown
+## API endpoints
+POST /api/users — create user. Body: { email, name, role }. Returns 201 with { id, ... }.
+GET /api/users/:id — fetch user.
+... [80 more lines]
+```
+
+**After:**
+```markdown
+## API endpoints
+See `docs/api-reference.md` for endpoint schemas and example payloads.
+```
+
+## 3. Step-by-step tutorials
+
+**Spot it:** Numbered lists with imperative steps, especially "first do X, then do Y, verify Z." Setup guides. "How to deploy" procedures.
+
+**Why it's a problem:** Tutorials are runnable procedures. Their natural home is either (a) a shell script, (b) a `Makefile`/`justfile` target, or (c) a Claude Skill that loads when the task triggers. Baking them into `CLAUDE.md` pays the context cost on every unrelated task.
+
+**Rewrite:** Extract to whichever of those three is appropriate.
+
+| Tutorial content | Best destination |
+|---|---|
+| "How to run migrations" | `scripts/migrate.sh` or `package.json` script |
+| "How to set up a new environment" | A Skill (runs on "set up new env" prompts) |
+| "How to add a new feature flag" | `docs/feature-flags.md`, linked from Quick reference |
+
+## 4. Preemptive file preloads
+
+**Spot it:** Instructions like "Read `src/config.ts` at session start", "Always load `docs/architecture.md` first", "Before responding, review `schema.prisma`."
+
+**Why it's a problem:** These force a read on every session, including tasks where the file is irrelevant. They also signal a lack of trust in on-demand reading, which tends to compound — next the user adds a second preload, then a third.
+
+**Rewrite:** Delete. Replace with a pointer in Quick reference: `Main schema: prisma/schema.prisma`. Claude will read it when the task calls for it.
+
+## 5. Ephemeral / dated state in the shared file
+
+**Spot it:** Status tables ("As of 2024-11-01, auth uses X"), current sprint info, open incident notes, "current" API tokens, active deploy environments with timestamps.
+
+**Why it's a problem:** This content goes stale fast, and when it does, it quietly misleads everyone who loads the file. It's also often personal to the author rather than team-shared.
+
+**Rewrite:** Move to `CLAUDE.local.md` (gitignored, personal) or delete. If the information is genuinely useful to the team and stable, rewrite it as a non-dated fact.
+
+## 6. Personal preferences in the project file
+
+**Spot it:** "I like terse responses", "Address me as <name>", "Always reply in English even if my message is in another language", personal aliases.
+
+**Why it's a problem:** The project `CLAUDE.md` is committed to the repo and shared with every collaborator. Your preferences aren't theirs.
+
+**Rewrite:** Move to `~/.claude/CLAUDE.md`, the user-level file.
+
+## 7. Duplicated skill content
+
+**Spot it:** Sections in `CLAUDE.md` that re-state something already covered in an installed Skill's `SKILL.md`.
+
+**Why it's a problem:** You're paying the cost twice — once in `CLAUDE.md` on every session, once in the skill when it triggers.
+
+**Rewrite:** Delete from `CLAUDE.md`. The skill loads when it's needed.
+
+## 8. Re-statements of general knowledge
+
+**Spot it:** Explanations of what Git is, how REST works, what TypeScript does.
+
+**Why it's a problem:** Claude already knows this. Re-stating it wastes context and reads as noise.
+
+**Rewrite:** Delete. Keep only non-obvious project-specific twists.
+
+## 9. "Just in case" notes
+
+**Spot it:** Content that's been in the file for months without being referenced. Notes like "If you run into X, do Y" where X has never actually happened.
+
+**Why it's a problem:** Every "just in case" note pays for itself every session, forever, whether or not the case ever occurs.
+
+**Rewrite:** Delete. If X does happen, the user can ask directly.
+
+## Quick decision tree
+
+When you look at a section and aren't sure whether to keep, extract, or delete:
+
+1. **Is this needed on more than half of interactions with this repo?** If no → extract or delete.
+2. **Is this team-shared, or personal to the author?** Personal → `~/.claude/CLAUDE.md` or `CLAUDE.local.md`.
+3. **Is this stable fact, or dated state?** Dated → `CLAUDE.local.md` or rewrite non-dated.
+4. **Does a Skill already cover this?** Yes → delete.
+5. **Is this a runnable procedure?** Yes → script or Skill, not prose.
+6. **Is this general knowledge Claude already has?** Yes → delete, keep only the project-specific twist.
+
+If after all six it still passes, it earns its place in the project `CLAUDE.md`.

--- a/plugins/agents-md-optimizer/skills/agents-md-optimizer/references/template.md
+++ b/plugins/agents-md-optimizer/skills/agents-md-optimizer/references/template.md
@@ -1,0 +1,74 @@
+# Lean CLAUDE.md template
+
+Use this skeleton when authoring a new `CLAUDE.md`. Keep the whole file to roughly one screen. If a section has nothing real to say, delete the section — don't pad with "TBD."
+
+```markdown
+# Project: <short name>
+
+## What this is
+
+<2–3 sentences explaining what the codebase does, who it's for, and why it
+exists. Someone skimming this should know whether they're in the right repo.>
+
+## Tech stack
+
+- **Language:** <e.g., TypeScript 5, Python 3.12>
+- **Framework:** <e.g., Next.js 15 (App Router), FastAPI>
+- **Key APIs:** <only the ones that matter for every task — the rest go in docs/>
+- **Deploy:** <e.g., Vercel + Cloud Run worker; Fly.io; GitHub Pages>
+- **Testing:** <e.g., Vitest + Playwright; pytest + hypothesis>
+
+## Code conventions
+
+- <Positive rule 1 — e.g., "Prefer server components; opt into `'use client'`
+  only where interactivity is needed.">
+- <Positive rule 2 — e.g., "Validate every external input with a `zod` schema
+  at the boundary.">
+- <3–7 rules total. Each one should be the kind of thing a new contributor
+  would get wrong on their first PR without it.>
+
+## Output preferences
+
+- <e.g., "Show a brief diff summary before large edits; small edits just ship.">
+- <e.g., "Keep code snippets under ~60 lines; link to the full file instead.">
+- <e.g., "Explain the why, not the what — assume the reader can read the diff.">
+
+## Boundaries
+
+- **Never commit:** <secrets, `.env*`, generated artifacts — the hard list>
+- **Always run before finishing:** <e.g., `pnpm lint && pnpm typecheck && pnpm test`>
+- <Any other hard stop — e.g., "Don't touch `prisma/migrations/`; use
+  `prisma migrate` instead.">
+
+## Quick reference
+
+- **Main entry:** <path/to/entry>
+- **Routes / handlers:** <path>
+- **Tests:** <path>
+- **Deeper docs:** <`docs/` — list 2–3 key files by name, don't embed them>
+- **Canonical knowledge:** <link to Notion / Confluence / wiki>
+```
+
+## Section notes
+
+**What this is.** Resist the urge to market the project here. This is orientation, not a pitch. If you find yourself listing features, stop — features belong in the README, not `CLAUDE.md`.
+
+**Tech stack.** One line per entry is the target. If you need two lines to describe a single dependency, it probably needs its own doc in `docs/`.
+
+**Code conventions.** Frame rules as positives ("Use const/let"), not negatives ("Don't use var"). Positives are shorter and they tell Claude what to do instead of what to avoid. The exception is genuine hard stops ("Never modify files under `vendor/`") — those belong in Boundaries, not Conventions.
+
+**Output preferences.** This is the most overlooked section. It's where you tune Claude's communication style for this repo specifically. A repo of quick utility scripts wants terse output; a monorepo with onboarding concerns wants more explanation. State the preference explicitly.
+
+**Boundaries.** Only put hard stops here. Soft preferences belong in Conventions. If a rule has exceptions and judgment calls, it's a Convention. If violating it is a breaking incident, it's a Boundary.
+
+**Quick reference.** Point to files by path, not by content. `See docs/api.md` is correct; pasting the contents of `docs/api.md` into `CLAUDE.md` defeats the point.
+
+## What *not* to include
+
+- API documentation. Link to it.
+- Architecture deep-dives. Link to them.
+- Historical decisions / changelogs. Those belong in `CHANGELOG.md` or PR descriptions.
+- Per-session state (current branch, active sprint, recent incidents). That belongs in `CLAUDE.local.md` or nowhere at all.
+- Personal communication preferences ("I prefer concise answers"). That belongs in `~/.claude/CLAUDE.md`, the user-level file, because it applies to all projects.
+- Full hook JSON blocks, setup commands, install scripts. If it's a runnable procedure, it's a script or a Skill, not prose in `CLAUDE.md`.
+- Re-statements of things Claude already knows (what Git is, what Python is, how HTTP works).

--- a/plugins/agents-md-optimizer/skills/agents-md-optimizer/scripts/audit.py
+++ b/plugins/agents-md-optimizer/skills/agents-md-optimizer/scripts/audit.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+audit.py — quantitative audit of a CLAUDE.md file.
+
+Usage:
+    python3 audit.py <path-to-CLAUDE.md>
+    python3 audit.py <path> --json        # machine-readable output
+    python3 audit.py <path> --strict      # exit 1 if any anti-pattern found
+
+Reports: line count, rough token estimate (~4 chars/token), detected
+anti-patterns with line numbers, per-section sizes. Never modifies the file.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+TARGET_LINES = 200
+TARGET_TOKENS = 1600
+CHARS_PER_TOKEN = 4  # rough heuristic for English prose + code
+
+# Regex patterns for anti-patterns. Each tuple is (pattern, label, explanation).
+ANTI_PATTERNS = [
+    (
+        re.compile(r"^\s*(don't|do not|never|avoid)\b", re.IGNORECASE),
+        "negative-rule",
+        "Negative rule — flip to a positive directive where possible.",
+    ),
+    (
+        re.compile(r"^(read|load|always load|before responding,?\s+review)\s+[`'\"/\w./-]+", re.IGNORECASE),
+        "preemptive-preload",
+        "Preemptive file preload — delete; Claude reads on demand.",
+    ),
+    (
+        re.compile(r"as of \d{4}|\b20\d{2}-\d{2}-\d{2}\b|current sprint|current status", re.IGNORECASE),
+        "dated-state",
+        "Dated / ephemeral state — move to CLAUDE.local.md or rewrite non-dated.",
+    ),
+    (
+        re.compile(r"^\s*(i like|i prefer|address me as|call me|please use my)\b", re.IGNORECASE),
+        "personal-preference",
+        "Personal preference — move to ~/.claude/CLAUDE.md (user-level).",
+    ),
+]
+
+# Crude heuristic: a code block (between ``` fences) longer than this is
+# probably reference material that should be extracted.
+LONG_CODE_BLOCK_THRESHOLD = 20
+
+
+@dataclass
+class Finding:
+    line: int
+    label: str
+    text: str
+    note: str
+
+
+@dataclass
+class Section:
+    heading: str
+    start_line: int
+    end_line: int
+    line_count: int
+    char_count: int
+
+
+@dataclass
+class Report:
+    path: str
+    total_lines: int
+    non_empty_lines: int
+    char_count: int
+    token_estimate: int
+    target_lines: int = TARGET_LINES
+    target_tokens: int = TARGET_TOKENS
+    over_line_target: bool = False
+    over_token_target: bool = False
+    sections: list[Section] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
+    long_code_blocks: list[dict] = field(default_factory=list)
+
+
+def parse_sections(lines: list[str]) -> list[Section]:
+    """Split by top-level (## or #) headings."""
+    sections: list[Section] = []
+    current_heading = "(preamble)"
+    current_start = 1
+    current_lines: list[str] = []
+
+    def flush(end_line: int) -> None:
+        if not current_lines:
+            return
+        char_count = sum(len(l) for l in current_lines)
+        sections.append(
+            Section(
+                heading=current_heading,
+                start_line=current_start,
+                end_line=end_line,
+                line_count=len(current_lines),
+                char_count=char_count,
+            )
+        )
+
+    for i, line in enumerate(lines, start=1):
+        if re.match(r"^#{1,3}\s+\S", line):
+            flush(i - 1)
+            current_heading = line.strip().lstrip("#").strip()
+            current_start = i
+            current_lines = [line]
+        else:
+            current_lines.append(line)
+    flush(len(lines))
+    return sections
+
+
+def find_long_code_blocks(lines: list[str]) -> list[dict]:
+    blocks = []
+    in_block = False
+    start = 0
+    for i, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not in_block and stripped.startswith("```"):
+            in_block = True
+            start = i
+            continue
+        if in_block and stripped.startswith("```"):
+            length = i - start - 1
+            if length > LONG_CODE_BLOCK_THRESHOLD:
+                blocks.append({"start_line": start, "end_line": i, "length": length})
+            in_block = False
+    return blocks
+
+
+def scan_anti_patterns(lines: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for i, line in enumerate(lines, start=1):
+        for pattern, label, note in ANTI_PATTERNS:
+            if pattern.search(line):
+                findings.append(
+                    Finding(line=i, label=label, text=line.rstrip()[:120], note=note)
+                )
+                break  # one label per line
+    return findings
+
+
+def audit(path: Path) -> Report:
+    raw = path.read_text(encoding="utf-8")
+    lines = raw.splitlines()
+    non_empty = sum(1 for l in lines if l.strip())
+    char_count = len(raw)
+    token_estimate = char_count // CHARS_PER_TOKEN
+
+    report = Report(
+        path=str(path),
+        total_lines=len(lines),
+        non_empty_lines=non_empty,
+        char_count=char_count,
+        token_estimate=token_estimate,
+        over_line_target=len(lines) > TARGET_LINES,
+        over_token_target=token_estimate > TARGET_TOKENS,
+        sections=parse_sections(lines),
+        findings=scan_anti_patterns(lines),
+        long_code_blocks=find_long_code_blocks(lines),
+    )
+    return report
+
+
+def format_text(r: Report) -> str:
+    out = []
+    out.append(f"CLAUDE.md audit — {r.path}")
+    out.append("=" * 60)
+    out.append(f"Total lines:      {r.total_lines:>5}   (target ≤{r.target_lines})")
+    out.append(f"Non-empty lines:  {r.non_empty_lines:>5}")
+    out.append(f"Characters:       {r.char_count:>5}")
+    out.append(f"Token estimate:   {r.token_estimate:>5}   (target ≤{r.target_tokens}, ~{CHARS_PER_TOKEN} chars/token)")
+
+    verdict_parts = []
+    if r.over_line_target:
+        verdict_parts.append(f"{r.total_lines - r.target_lines} lines over target")
+    if r.over_token_target:
+        verdict_parts.append(f"~{r.token_estimate - r.target_tokens} tokens over target")
+    if verdict_parts:
+        out.append("Verdict:          OVER — " + "; ".join(verdict_parts))
+    else:
+        out.append("Verdict:          within lean target")
+
+    out.append("")
+    out.append("Sections")
+    out.append("-" * 60)
+    for s in r.sections:
+        out.append(f"  L{s.start_line:>3}-{s.end_line:<3} [{s.line_count:>3} lines, ~{s.char_count // CHARS_PER_TOKEN:>4} tok]  {s.heading}")
+
+    if r.long_code_blocks:
+        out.append("")
+        out.append(f"Long code blocks (>{LONG_CODE_BLOCK_THRESHOLD} lines — candidates to extract)")
+        out.append("-" * 60)
+        for b in r.long_code_blocks:
+            out.append(f"  L{b['start_line']:>3}-{b['end_line']:<3}  ({b['length']} lines)")
+
+    if r.findings:
+        out.append("")
+        out.append("Anti-patterns detected")
+        out.append("-" * 60)
+        by_label: dict[str, list[Finding]] = {}
+        for f in r.findings:
+            by_label.setdefault(f.label, []).append(f)
+        for label, items in by_label.items():
+            out.append(f"  [{label}]  {items[0].note}")
+            for f in items[:5]:
+                out.append(f"    L{f.line:>3}: {f.text}")
+            if len(items) > 5:
+                out.append(f"    … and {len(items) - 5} more")
+    else:
+        out.append("")
+        out.append("No anti-patterns matched by regex.")
+
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", help="Path to CLAUDE.md (or any .md file to audit)")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 if the file is over target or has anti-patterns.",
+    )
+    args = parser.parse_args()
+
+    path = Path(args.path)
+    if not path.exists():
+        print(f"error: file not found: {path}", file=sys.stderr)
+        return 2
+
+    report = audit(path)
+
+    if args.json:
+        print(json.dumps(asdict(report), indent=2, default=str))
+    else:
+        print(format_text(report))
+
+    if args.strict and (report.over_line_target or report.over_token_target or report.findings):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds the `agents-md-optimizer` plugin to the catalog, ported from the local skill at `.claude/skills/agents-md-optimizer/`
- Provides **audit mode** (reads an existing CLAUDE.md, runs quantitative analysis, produces a lean rewrite + extraction plan) and **author mode** (interviews the user and writes a fresh lean file from scratch)
- Ships with a reusable `audit.py` script that reports line count, token estimate, anti-pattern hits, and section sizes — usable standalone from the CLI

## Plugin folder structure

\`\`\`
plugins/agents-md-optimizer/
├── .claude-plugin/
│   └── plugin.json           — metadata, SOSA level 2, keywords
├── CLAUDE.md                 — lean plugin-level notes
├── README.md                 — install guide, anti-pattern table, usage
└── skills/
    └── agents-md-optimizer/
        ├── SKILL.md          — full skill (trigger phrases, audit + author mode, output format)
        ├── references/
        │   ├── template.md   — lean CLAUDE.md skeleton for author mode
        │   └── anti-patterns.md — catalog of 9 bloat patterns with before/after rewrites
        └── scripts/
            └── audit.py      — CLI audit tool (line count, token estimate, anti-pattern detection)
\`\`\`

## Test plan

- [ ] Install plugin in a Cowork session and trigger with "my CLAUDE.md is too big"
- [ ] Point it at a large CLAUDE.md — verify audit output includes stats + extraction plan
- [ ] Run `python3 scripts/audit.py <path>` directly — verify text and `--json` modes
- [ ] Trigger author mode with "write a CLAUDE.md for my new project" — verify interview + output
- [ ] Run `--strict` flag on a clean file — verify exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)