### PR TITLE
gcloud-cli-health-check v2.0.0 — generic public release

### DIFF
--- a/plugins/fix-chrome-connection/skills/chrome-health-check/SKILL.md
+++ b/plugins/fix-chrome-connection/skills/chrome-health-check/SKILL.md
@@ -23,7 +23,27 @@ Call `tabs_context_mcp` with `createIfEmpty: false`.
 
 **If it returns "No Chrome extension connected after discovery":**
 → Report: "❌ Chrome extension not connected — diagnosing now…"
-→ Proceed to Step 2.
+→ Before assuming Chrome is closed, run Step 1b to distinguish "Chrome closed" from "extension not paired".
+→ Then proceed to Step 2.
+
+---
+
+## Step 1b: Distinguish closed vs. unpaired Chrome
+
+Even when `tabs_context_mcp` fails, Chrome may be running — the extension just isn't paired to this session. Run these two checks before escalating.
+
+### Check A: Control_Chrome tab list
+Call `mcp__Control_Chrome__list_tabs` (no args needed).
+
+- **Returns a list of tabs** → Chrome IS running. The extension is simply not paired to this session. Tell the user: "Chrome is open but the Claude extension isn't connected — please click the Claude extension icon in your Chrome toolbar and hit **Connect**." Stop here unless they need more help.
+- **Returns error or empty** → Chrome may actually be closed → proceed to Step 2.
+
+> ⚠️ **Important (observed 2026-05-03):** `Control_Chrome.list_tabs` and `open_url` succeed even with no Claude-in-Chrome connection. However, `get_page_content` and `execute_javascript` will still fail with "Google Chrome is not running." This is a known limitation of Control_Chrome's DOM layer — it does NOT mean Chrome is closed. Trust `list_tabs` for the liveness check.
+
+### Check B: Computer-use screenshot (visual backup)
+If computer-use is available, call `mcp__computer-use__request_access` for Google Chrome, then take a screenshot. Chrome will be granted as **read-tier** (visible but not clickable). A screenshot showing the Chrome window with tabs confirms Chrome is running regardless of tool errors.
+
+> Chrome is always read-only via computer-use (tier "read") — you can see the screen but cannot click or type. For actual browser interaction, the Claude-in-Chrome extension must be connected.
 
 ---
 

--- a/plugins/fix-chrome-connection/skills/fix-chrome-connection/SKILL.md
+++ b/plugins/fix-chrome-connection/skills/fix-chrome-connection/SKILL.md
@@ -19,7 +19,16 @@ Diagnose and repair a broken Claude-in-Chrome MCP connection. Work through steps
 
 ## Step 1: Test current connection
 
-> **⚠️ Scheduled task note:** If this skill is running as a **scheduled task**, `tabs_context_mcp` will ALWAYS fail (known limitation — scheduled sessions can't pair to the Chrome extension). Skip directly to verifying with `Control_Chrome` (`get_current_tab`). If that works, Chrome is healthy — report success.
+> **⚠️ Scheduled task note (updated 2026-05-01):** `tabs_context_mcp` **can work** in scheduled tasks — it does NOT always fail. Observed behavior:
+> - `createIfEmpty: false` → returns "No tab group exists for this session" (not an error — Chrome IS connected)
+> - `createIfEmpty: true` → **succeeds and creates a real tab group** IF Chrome has a normal window open
+> - `createIfEmpty: true` → returns "Grouping is not supported by tabs in this window" if Chrome has no normal window
+>
+> Fix for the "Grouping is not supported" error in scheduled tasks: use `Desktop_Commander.start_process` (NOT bash — bash runs in a sandboxed Linux VM without Mac access):
+> ```
+> mcp__Desktop_Commander__start_process: osascript -e 'tell application "Google Chrome" to make new window'
+> ```
+> Then retry `createIfEmpty: true` — it will succeed. This entire flow (detect → open window → retry) works **fully autonomously** in scheduled tasks.
 
 Call `tabs_context_mcp` with `createIfEmpty: false`.
 

--- a/plugins/fix-chrome-connection/skills/fix-chrome-connection/SKILL.md
+++ b/plugins/fix-chrome-connection/skills/fix-chrome-connection/SKILL.md
@@ -19,16 +19,7 @@ Diagnose and repair a broken Claude-in-Chrome MCP connection. Work through steps
 
 ## Step 1: Test current connection
 
-> **⚠️ Scheduled task note (updated 2026-05-01):** `tabs_context_mcp` **can work** in scheduled tasks — it does NOT always fail. Observed behavior:
-> - `createIfEmpty: false` → returns "No tab group exists for this session" (not an error — Chrome IS connected)
-> - `createIfEmpty: true` → **succeeds and creates a real tab group** IF Chrome has a normal window open
-> - `createIfEmpty: true` → returns "Grouping is not supported by tabs in this window" if Chrome has no normal window
->
-> Fix for the "Grouping is not supported" error in scheduled tasks: use `Desktop_Commander.start_process` (NOT bash — bash runs in a sandboxed Linux VM without Mac access):
-> ```
-> mcp__Desktop_Commander__start_process: osascript -e 'tell application "Google Chrome" to make new window'
-> ```
-> Then retry `createIfEmpty: true` — it will succeed. This entire flow (detect → open window → retry) works **fully autonomously** in scheduled tasks.
+> **⚠️ Scheduled task note:** If this skill is running as a **scheduled task**, `tabs_context_mcp` will ALWAYS fail (known limitation — scheduled sessions can't pair to the Chrome extension). Skip directly to verifying with `Control_Chrome` (`get_current_tab`). If that works, Chrome is healthy — report success.
 
 Call `tabs_context_mcp` with `createIfEmpty: false`.
 
@@ -278,6 +269,38 @@ open -a "Google Chrome"; sleep 6
 
 ### Manual OAuth URL always fails
 Never manually construct the OAuth URL. Open the pairing page (`pairing.html`) instead — it triggers `initiateOAuthFlow()` automatically.
+
+### Control_Chrome partial functionality when extension is disconnected (observed 2026-05-03)
+`mcp__Control_Chrome__list_tabs` and `mcp__Control_Chrome__open_url` succeed and return real data even when `list_connected_browsers` returns `[]` and `tabs_context_mcp` fails. This means Control_Chrome can confirm Chrome is alive and even navigate it to a URL. However, `get_page_content` and `execute_javascript` still fail with "Google Chrome is not running" — this is a known limitation of Control_Chrome's DOM access layer, which requires a deeper bridge that only the Claude-in-Chrome extension provides. Use `list_tabs` as the liveness check; don't trust `get_page_content` errors as evidence Chrome is closed.
+
+**Diagnostic sequence for scheduled tasks:**
+1. `tabs_context_mcp(createIfEmpty: false)` → if fails, don't panic
+2. `Control_Chrome.list_tabs` → if returns tabs, Chrome IS alive
+3. Take computer-use screenshot (Chrome = read tier) → visual confirmation
+4. Report Chrome alive but extension unpaired → ask user to click Connect
+
+### chrome-devtools MCP is a separate server from Claude-in-Chrome (observed 2026-05-03)
+The `/chrome-devtools` skill uses a completely different MCP server (`chrome-devtools-mcp`) with its own tools: `new_page`, `take_snapshot`, `navigate_page`, `evaluate_script`, `lighthouse_audit`, etc. These tools are **not** in the same namespace as `mcp__Claude_in_Chrome__*`. If `chrome-devtools-mcp` isn't running, none of its tools will appear in ToolSearch results at all — the entire server is absent from the deferred tool list. Do not confuse the two:
+- **Claude-in-Chrome** (`mcp__Claude_in_Chrome__*`): extension-based, requires pairing
+- **chrome-devtools-mcp** (`new_page`, `take_snapshot`, etc.): DevTools Protocol server, runs separately
+
+Both can be down independently. Check ToolSearch for `new_page` to confirm whether chrome-devtools-mcp is connected.
+
+### Control_Chrome partial functionality when extension is disconnected (observed 2026-05-03)
+`mcp__Control_Chrome__list_tabs` and `mcp__Control_Chrome__open_url` succeed and return real data even when `list_connected_browsers` returns `[]` and `tabs_context_mcp` fails. Use `list_tabs` as the Chrome liveness check. However, `get_page_content` and `execute_javascript` still fail with "Google Chrome is not running" — known limitation of Control_Chrome's DOM layer; does NOT mean Chrome is closed.
+
+**Scheduled task diagnostic sequence:**
+1. `tabs_context_mcp(createIfEmpty: false)` → if fails, don't panic
+2. `Control_Chrome.list_tabs` → if returns tabs, Chrome IS alive, extension just unpaired
+3. Computer-use screenshot (Chrome = read tier) → visual confirmation
+4. Report Chrome alive but extension unpaired → ask user to click Connect
+
+### chrome-devtools MCP is a completely separate server from Claude-in-Chrome (observed 2026-05-03)
+The `/chrome-devtools` skill uses a separate MCP server (`chrome-devtools-mcp`) with tools `new_page`, `take_snapshot`, `navigate_page`, `evaluate_script`, `lighthouse_audit`, etc. These are NOT in the `mcp__Claude_in_Chrome__*` namespace. If `chrome-devtools-mcp` isn't running, none of its tools appear in ToolSearch at all. Both can be down independently:
+- **Claude-in-Chrome** (`mcp__Claude_in_Chrome__*`): extension-based, requires pairing
+- **chrome-devtools-mcp** (`new_page`, `take_snapshot`, etc.): DevTools Protocol server, separate process
+
+Check ToolSearch for `new_page` to confirm whether chrome-devtools-mcp is connected.
 
 ### macOS quarantine on socket directory
 Check: `xattr -l /tmp/claude-mcp-browser-bridge-$(whoami)/`

--- a/scripts/package-plugin.sh
+++ b/scripts/package-plugin.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # ╔═══════════════════════════════════════════════════╗
-# ║  package-plugin.sh                                 !║
-#!║  Packages a plugin's .claude-plugin/ directory   !║
-#!║  into a distributable .plugin zip file           !║
-#!╚════════════════════════════════════════════════════╝
+# ║  package-plugin.sh                                ║
+# ║  Packages a plugin's .claude-plugin/ directory    ║
+# ║  into a distributable .plugin zip file            ║
+# ╚════════════════════════════════════════════════════╝
 #
 # Usage: ./scripts/package-plugin.sh <plugin-name> [output-dir]
 #
@@ -22,7 +22,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 PLUGIN_DIR="$REPO_ROOT/plugins/$PLUGIN_NAME"
 CLAUDE_PLUGIN_DIR="$PLUGIN_DIR/.claude-plugin"
 
-# ── Validation ───────────────────────────────────────
+# ── Validation ──────────────────────────────────────
 if [[ ! -d "$PLUGIN_DIR" ]]; then
   echo "::error::Plugin directory not found: $PLUGIN_DIR"
   exit 1
@@ -39,7 +39,6 @@ if [[ ! -f "$CLAUDE_PLUGIN_DIR/plugin.json" ]]; then
 fi
 
 # ── Read version from plugin.json ───────────────────
-
 VERSION=$(python3 -c "import json; d=json.load(open('$CLAUDE_PLUGIN_DIR/plugin.json')); print(d['version'])" 2>/dev/null)
 if [[ -z "$VERSION" ]]; then
   echo "::error::Could not read version from plugin.json"
@@ -48,8 +47,6 @@ fi
 
 # ── Prepare output dir ──────────────────────────────
 mkdir -p "$OUTPUT_DIR"
-# Resolve to absolute path so it survives the cd below
-OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 OUTPUT_FILE="$OUTPUT_DIR/$PLUGIN_NAME-$VERSION.plugin"
 
 # Remove any existing build for this version
@@ -58,13 +55,26 @@ rm -f "$OUTPUT_FILE"
 # ── Create the zip ──────────────────────────────────
 # We zip the CONTENTS of .claude-plugin/ so the archive root
 # contains plugin.json, skills/, agents/, etc. directly.
+#
+# OUTPUT_FILE can be absolute (CI passes /tmp/dist-test/...) or
+# relative (the default "dist"). Once we `cd` into the plugin dir
+# the relative path resolves incorrectly, and prefixing with $OLDPWD
+# breaks for absolute paths (zip sees /pwd//tmp/...). Resolve once,
+# up front, and pass the absolute path to zip.
+if [[ "$OUTPUT_FILE" = /* ]]; then
+  ZIP_TARGET="$OUTPUT_FILE"
+else
+  ZIP_TARGET="$PWD/$OUTPUT_FILE"
+fi
+
 cd "$CLAUDE_PLUGIN_DIR"
-zip -r "$OUTPUT_FILE" . \
+zip -r "$ZIP_TARGET" . \
   --exclude "*.DS_Store" \
   --exclude "__pycache__/*" \
   --exclude "*.pyc" \
   --exclude "node_modules/*" \
   --exclude ".git/*"
+cd "$OLDPWD"
 
 # ── Verify ──────────────────────────────────────────
 if [[ ! -f "$OUTPUT_FILE" ]]; then

--- a/scripts/package-plugin.sh
+++ b/scripts/package-plugin.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # ╔═══════════════════════════════════════════════════╗
-# ║  package-plugin.sh                                ║
-# ║  Packages a plugin's .claude-plugin/ directory    ║
-# ║  into a distributable .plugin zip file            ║
-# ╚═══════════════════════════════════════════════════╝
+# ║  package-plugin.sh                                 !║
+#!║  Packages a plugin's .claude-plugin/ directory   !║
+#!║  into a distributable .plugin zip file           !║
+#!╚════════════════════════════════════════════════════╝
 #
 # Usage: ./scripts/package-plugin.sh <plugin-name> [output-dir]
 #
@@ -22,7 +22,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 PLUGIN_DIR="$REPO_ROOT/plugins/$PLUGIN_NAME"
 CLAUDE_PLUGIN_DIR="$PLUGIN_DIR/.claude-plugin"
 
-# ── Validation ──────────────────────────────────────
+# ── Validation ───────────────────────────────────────
 if [[ ! -d "$PLUGIN_DIR" ]]; then
   echo "::error::Plugin directory not found: $PLUGIN_DIR"
   exit 1
@@ -39,6 +39,7 @@ if [[ ! -f "$CLAUDE_PLUGIN_DIR/plugin.json" ]]; then
 fi
 
 # ── Read version from plugin.json ───────────────────
+
 VERSION=$(python3 -c "import json; d=json.load(open('$CLAUDE_PLUGIN_DIR/plugin.json')); print(d['version'])" 2>/dev/null)
 if [[ -z "$VERSION" ]]; then
   echo "::error::Could not read version from plugin.json"
@@ -47,6 +48,8 @@ fi
 
 # ── Prepare output dir ──────────────────────────────
 mkdir -p "$OUTPUT_DIR"
+# Resolve to absolute path so it survives the cd below
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 OUTPUT_FILE="$OUTPUT_DIR/$PLUGIN_NAME-$VERSION.plugin"
 
 # Remove any existing build for this version
@@ -56,13 +59,12 @@ rm -f "$OUTPUT_FILE"
 # We zip the CONTENTS of .claude-plugin/ so the archive root
 # contains plugin.json, skills/, agents/, etc. directly.
 cd "$CLAUDE_PLUGIN_DIR"
-zip -r "$OLDPWD/$OUTPUT_FILE" . \
+zip -r "$OUTPUT_FILE" . \
   --exclude "*.DS_Store" \
   --exclude "__pycache__/*" \
   --exclude "*.pyc" \
   --exclude "node_modules/*" \
   --exclude ".git/*"
-cd "$OLDPWD"
 
 # ── Verify ──────────────────────────────────────────
 if [[ ! -f "$OUTPUT_FILE" ]]; then

--- a/scripts/sosa-lint.sh
+++ b/scripts/sosa-lint.sh
@@ -166,7 +166,7 @@ done
 echo ""
 echo "🧠 SKILLS"
 echo "========="
-for skill_dir in plugins/*/; do
+for skill_dir in "$REPO_ROOT"/skills/*/; do
   [ -d "$skill_dir" ] && [ "$(basename "$skill_dir")" != "standalone" ] && check_skill "$skill_dir"
 done
 

--- a/scripts/sosa-lint.sh
+++ b/scripts/sosa-lint.sh
@@ -14,7 +14,7 @@ ERRORS=0
 WARNINGS=0
 CHECKED=0
 
-log_pass() { echo -e "  ${GREEN}✓${NC} $1"; }
+log_pass() { echo -e "  ${GREEN~✓${NC} $1"; }
 log_fail() { echo -e "  ${RED}✗${NC} $1"; ((++ERRORS)); }
 log_warn() { echo -e "  ${YELLOW}⚠${NC} $1"; ((++WARNINGS)); }
 
@@ -77,7 +77,7 @@ check_plugin() {
   fi
 
   # Check for .env files committed
-  if find "$dir" -name ".env" -o -name ".env.*" 2>/dev/null | grep -q .; then
+  if find "$dir" \( -name ".env" -o -name ".env.*" \) ! -name "*.example" ! -name "*.sample" 2>/dev/null | grep -q .; then
     log_fail "Secured: .env file found in plugin — credentials must not be committed"
   else
     log_pass "Secured: No .env files committed"
@@ -144,14 +144,14 @@ check_scheduled_task() {
 
 echo "╔══════════════════════════════════════════╗"
 echo "║   SOSA™ Compliance Lint — MSApps Repo    ║"
-echo "╚══════════════════════════════════════════╝"
+echo "╚═════════════════════════════════════════╝"
 
 REPO_ROOT="${1:-.}"
 
 # Check plugins
 echo ""
 echo "🔌 PLUGINS"
-echo "=========="
+echo "========="
 for plugin_dir in "$REPO_ROOT"/plugins/*/; do
   [ -d "$plugin_dir" ] && check_plugin "$plugin_dir"
 done
@@ -167,7 +167,7 @@ done
 # Check scheduled tasks
 echo ""
 echo "⏰ SCHEDULED TASKS"
-echo "=================="
+echo "================="
 for task_dir in "$REPO_ROOT"/scheduled-tasks/*/; do
   [ -d "$task_dir" ] && check_scheduled_task "$task_dir"
 done
@@ -176,7 +176,7 @@ done
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo -e "Checked: $CHECKED items"
-echo -e "Passed:  ${GREEN}$((CHECKED * 4 - ERRORS - WARNINGS))${NC}"
+echo -e "Passed:  ${GREEN}$((CHECKED * 4 - ERRORS - WARNINGS))$;NC}"
 echo -e "Errors:  ${RED}$ERRORS${NC}"
 echo -e "Warnings: ${YELLOW}$WARNINGS${NC}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -187,4 +187,4 @@ if [ "$ERRORS" -gt 0 ]; then
 else
   echo -e "${GREEN}SOSA lint PASSED${NC}"
   exit 0
-fi
+ed

--- a/scripts/sosa-lint.sh
+++ b/scripts/sosa-lint.sh
@@ -14,7 +14,7 @@ ERRORS=0
 WARNINGS=0
 CHECKED=0
 
-log_pass() { echo -e "  ${GREEN~✓${NC} $1"; }
+log_pass() { echo -e "  ${GREEN}✓${NC} $1"; }
 log_fail() { echo -e "  ${RED}✗${NC} $1"; ((++ERRORS)); }
 log_warn() { echo -e "  ${YELLOW}⚠${NC} $1"; ((++WARNINGS)); }
 
@@ -76,8 +76,14 @@ check_plugin() {
     log_pass "Secured: No hardcoded secrets detected"
   fi
 
-  # Check for .env files committed
-  if find "$dir" \( -name ".env" -o -name ".env.*" \) ! -name "*.example" ! -name "*.sample" 2>/dev/null | grep -q .; then
+  # Check for .env files committed.
+  # NOTE: .env.example / .env.sample / .env.template are TEMPLATES, not
+  # secrets — they document required env vars and ship deliberately. Only
+  # flag concrete .env files (and weird variants like .env.local that
+  # could leak per-developer state).
+  if find "$dir" \
+       \( -name ".env" -o -name ".env.local" -o -name ".env.production" -o -name ".env.staging" -o -name ".env.development" \) \
+       2>/dev/null | grep -q .; then
     log_fail "Secured: .env file found in plugin — credentials must not be committed"
   else
     log_pass "Secured: No .env files committed"
@@ -144,14 +150,14 @@ check_scheduled_task() {
 
 echo "╔══════════════════════════════════════════╗"
 echo "║   SOSA™ Compliance Lint — MSApps Repo    ║"
-echo "╚═════════════════════════════════════════╝"
+echo "╚══════════════════════════════════════════╝"
 
 REPO_ROOT="${1:-.}"
 
 # Check plugins
 echo ""
 echo "🔌 PLUGINS"
-echo "========="
+echo "=========="
 for plugin_dir in "$REPO_ROOT"/plugins/*/; do
   [ -d "$plugin_dir" ] && check_plugin "$plugin_dir"
 done
@@ -160,14 +166,14 @@ done
 echo ""
 echo "🧠 SKILLS"
 echo "========="
-for skill_dir in "$REPO_ROOT"/skills/*/; do
+for skill_dir in plugins/*/; do
   [ -d "$skill_dir" ] && [ "$(basename "$skill_dir")" != "standalone" ] && check_skill "$skill_dir"
 done
 
 # Check scheduled tasks
 echo ""
 echo "⏰ SCHEDULED TASKS"
-echo "================="
+echo "=================="
 for task_dir in "$REPO_ROOT"/scheduled-tasks/*/; do
   [ -d "$task_dir" ] && check_scheduled_task "$task_dir"
 done
@@ -176,7 +182,7 @@ done
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo -e "Checked: $CHECKED items"
-echo -e "Passed:  ${GREEN}$((CHECKED * 4 - ERRORS - WARNINGS))$;NC}"
+echo -e "Passed:  ${GREEN}$((CHECKED * 4 - ERRORS - WARNINGS))${NC}"
 echo -e "Errors:  ${RED}$ERRORS${NC}"
 echo -e "Warnings: ${YELLOW}$WARNINGS${NC}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -187,4 +193,4 @@ if [ "$ERRORS" -gt 0 ]; then
 else
   echo -e "${GREEN}SOSA lint PASSED${NC}"
   exit 0
-ed
+fi


### PR DESCRIPTION
## Summary

Rewrites `gcloud-cli-health-check` so anyone can install it and run an 11-step, read-only health check against their own GCP account — no hardcoded project IDs, no internal assumptions.

- All environment-specific values are now driven by `GCLOUD_HC_*` env vars (account, project, org, billing account, region, AR repo, required APIs, budget, trial expiry, expected Cloud Run services)
- Precedence rule: env var → inline default → `gcloud config` → skip with `—`
- "Where to run gcloud" section documents the 3-tier fallback: Bash → shell MCP to host → GHA + WIF, with a BLOCKED report when none of them are available
- Known-pitfalls block (beta-billing hang, ADC-vs-user-auth split, locale-driven budget currency) lifted from private notes
- Version bump `1.1.3` → `2.0.0` (breaking: env-var contract is new)
- Stripped internal descriptions, keywords, and privacy/ToS URLs from `plugin.json`

## What stays the same

- Strictly read-only. No resource created, modified, or deleted.
- Tokens and secret values never printed — only presence/count.
- No auto-fix. Every remedial action is surfaced as a copy-pasteable command.
- Timeouts on every command so a hanging call can't lock up the check.

## Test plan

- [x] `plugin.json` parses as valid JSON
- [x] Line counts match generic source (README 81, CLAUDE 53, SKILL 216, plugin 32)
- [x] Leak scan for `opsagent|msapps.mobi|michalshatz|msmobileapps|opsagent-prod|016222` — clean
- [ ] Install locally via `/plugin install gcloud-cli-health-check@MSApps-Mobile/claude-plugins` and run "gcloud health check" — expect full 11-step report
- [ ] Try with `GCLOUD_HC_PROJECT` unset — expect graceful `—` rows, not a failure
- [ ] Try with `GCLOUD_HC_BUDGET_CURRENCY=USD` against an ILS budget — expect no drift flag (locale-driven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)