### PR TITLE
gcloud-cli-health-check v3.2.0: SSO reauth + config-set workaround

### DIFF
--- a/plugins/gcloud-cli-health-check/CLAUDE.md
+++ b/plugins/gcloud-cli-health-check/CLAUDE.md
@@ -135,6 +135,7 @@ Report:
 | 2.0.0 | 2026-04-20 | **Dual-path**: cloud Routine (primary) + Cowork+DC (fallback). New `routines/` directory. Updated primary project to `opsagent-prod` (migrated from `opsagent-491114`). SA key auth for Routine path (no personal token expiry). |
 | 3.0.0 | 2026-04-20 | **GitHub Actions as primary** — SA key approach replaced with WIF. New `.github/workflows/gcloud-health-check.yml`. WIF pool `claude-routines` + `roles/viewer` binding on `opsagent-prod`. Three-path documentation (GHA / Cowork+DC / VM Bash blocked). |
 | 3.1.0 | 2026-04-20 | **VM Bash permanently blocked confirmed** — Cowork settings checked; no network egress / domain allowlist controls exist on this plan. GitHub issues #30112/#34690 reference an Enterprise-only feature. GHA (primary) + Cowork+DC (fallback) are the only two live paths. |
+| 3.2.0 | 2026-04-21 | **Workspace SSO reauth + `config set` auto-fix workaround** — documented the `opsagents.agency` periodic refresh-token invalidation and the "switch-account → set → switch-back" workaround for `gcloud config set` when the primary token is blocked. Flagged `socialjetopsagent` as an active OpsAgent runtime project and marked `msmobileapps@gmail.com` stale for `opsagent-prod`. |
 
 ## Lessons Learned
 
@@ -158,3 +159,9 @@ Report:
 ### 2026-04-20 (v3.1.0)
 - **Network egress allowlist is not available on this plan** — Cowork settings panel shows only Dispatch + Instructions; no domain allowlist or "Allow network egress" toggle exists. GitHub issues #30112/#34690 suggest this is Enterprise-only. Do not spend time on VM Bash workarounds.
 - **GitHub Actions is the definitive answer** — WIF works natively, no credential expiry, no personal token management, runs on clean Ubuntu runners with full Google network access.
+
+### 2026-04-21 (v3.2.0)
+- **`opsagents.agency` Workspace SSO invalidates gcloud refresh tokens on a schedule.** Scheduled Cowork+DC runs fail silently with `ERROR: Reauthentication failed. cannot prompt during non-interactive execution.` when the Workspace session-control policy kicks in. Only interactive `gcloud auth login` (browser) repairs it. This is the **#1 reason the Cowork+DC fallback degrades between runs**. GHA path (WIF) does not have this problem — another reason GHA stays the primary.
+- **`gcloud config set <property>` requires a working refresh token on the active account** — even though it's a local-property write, it tries to refresh the active account's token on load and fails end-to-end if that token is blocked. **Auto-fix workaround, now standard:** temporarily switch to a working credentialed account (`gcloud config set account <other>`), set the property, switch the active account back. This unblocks region / project property fixes even when the primary token is dead.
+- **`msmobileapps@gmail.com` has no IAM on `opsagent-prod`** (403 permission denied on `projects describe`). The account architecture table called it "Legacy billing owner — same project, org-level" but that was true for `opsagent-491114`, not the new org-scoped `opsagent-prod`. Updated: on `opsagent-prod` it has no binding; stop treating it as a read fallback.
+- **`socialjetopsagent` is running three OpsAgent-core Cloud Run services** (`opsagent-core`, `opsagent-ai-runtime`, `opsagent-dashboard`) alongside the SocialJet + MyClaimPros stack — total 6 services. The project is an active OpsAgent runtime, not just "secondary / SocialJet ops." Decide whether to migrate these into `opsagent-prod` or document `socialjetopsagent` as a second prod project.

--- a/plugins/gcloud-cli-health-check/skills/gcloud-cli-health-check/SKILL.md
+++ b/plugins/gcloud-cli-health-check/skills/gcloud-cli-health-check/SKILL.md
@@ -11,8 +11,8 @@ description: >
   operational. Also triggered by the scheduled task named "gcloud-cli-health-check" (or the
   legacy name "gcloud-health-check").
 metadata:
-  version: "1.1.0"
-  updated: "2026-04-20"
+  version: "1.2.0"
+  updated: "2026-04-21"
   author: "MSApps"
 ---
 
@@ -35,7 +35,7 @@ If Desktop Commander is unavailable, do NOT try to install gcloud in the sandbox
 |---|---|
 | gcloud binary | `/opt/homebrew/bin/gcloud` (macOS, Homebrew) |
 | Active account | `michal@opsagents.agency` (primary) |
-| Active project | `opsagent-491114` |
+| Active project | `opsagent-prod` |
 | Compute region | `me-west1` (Israeli prod) |
 | Secondary project | `socialjetopsagent` (SocialJet Gmail/Calendar services) |
 
@@ -69,17 +69,17 @@ If no accounts at all → mark Auth ❌. If wrong account active → mark ⚠️
 ```bash
 /opt/homebrew/bin/gcloud config get-value project
 /opt/homebrew/bin/gcloud config get-value compute/region
-/opt/homebrew/bin/gcloud projects describe opsagent-491114 --format="value(lifecycleState,projectId,name)"
+/opt/homebrew/bin/gcloud projects describe opsagent-prod --format="value(lifecycleState,projectId,name)"
 ```
 
-- Project must be `opsagent-491114` and `lifecycleState=ACTIVE` → ✅
+- Project must be `opsagent-prod` and `lifecycleState=ACTIVE` → ✅
 - Region should be `me-west1` (warn ⚠️ if different, it still works)
 - Mismatch on project → ⚠️
 
 ## Step 4 — Billing
 
 ```bash
-/opt/homebrew/bin/gcloud billing projects describe opsagent-491114
+/opt/homebrew/bin/gcloud billing projects describe opsagent-prod
 ```
 
 - `billingEnabled: true` → ✅
@@ -90,7 +90,7 @@ Do NOT run `gcloud alpha billing accounts list` — it triggers an interactive p
 ## Step 5 — Enabled APIs (critical + optional)
 
 ```bash
-/opt/homebrew/bin/gcloud services list --enabled --project=opsagent-491114 --format="value(config.name)"
+/opt/homebrew/bin/gcloud services list --enabled --project=opsagent-prod --format="value(config.name)"
 ```
 
 Critical (must be enabled — flag ❌ if missing):
@@ -110,8 +110,8 @@ Optional (flag ⚠️ if missing):
 ## Step 6 — Cloud Run services (multi-region, multi-project)
 
 ```bash
-/opt/homebrew/bin/gcloud run services list --region=me-west1 --project=opsagent-491114
-/opt/homebrew/bin/gcloud run services list --region=us-central1 --project=opsagent-491114
+/opt/homebrew/bin/gcloud run services list --region=me-west1 --project=opsagent-prod
+/opt/homebrew/bin/gcloud run services list --region=us-central1 --project=opsagent-prod
 /opt/homebrew/bin/gcloud run services list --project=socialjetopsagent
 ```
 
@@ -120,7 +120,7 @@ Record: service name, region, URL, last deployed. If all three return zero servi
 ## Step 7 — IAM roles for michal@opsagents.agency
 
 ```bash
-/opt/homebrew/bin/gcloud projects get-iam-policy opsagent-491114 \
+/opt/homebrew/bin/gcloud projects get-iam-policy opsagent-prod \
   --flatten="bindings[].members" \
   --format="table(bindings.role)" \
   --filter="bindings.members:michal@opsagents.agency"
@@ -131,7 +131,7 @@ Record the roles. If `roles/owner` or `roles/editor` is present → ✅. If empt
 ## Step 8 — Service accounts
 
 ```bash
-/opt/homebrew/bin/gcloud iam service-accounts list --project=opsagent-491114
+/opt/homebrew/bin/gcloud iam service-accounts list --project=opsagent-prod
 ```
 
 Record the list. Flag if the default Compute Engine SA still has broad permissions (security best practice: replace with scoped SAs + Workload Identity).
@@ -152,7 +152,7 @@ Save as `gcloud-health-check-YYYY-MM-DD.md` in the workspace outputs folder (ove
 # gcloud CLI Health Check — YYYY-MM-DD HH:MM
 
 **Account:** michal@opsagents.agency
-**Project:** opsagent-491114 (+ socialjetopsagent)
+**Project:** opsagent-prod (+ socialjetopsagent)
 **Runner:** Desktop Commander (user's Mac)
 **Overall:** ✅ / ⚠️ / ❌
 
@@ -185,11 +185,24 @@ If any step fails, attempt these fixes via Desktop Commander before giving up (m
    - `which gcloud` to find an alternate path
    - `brew install --cask google-cloud-sdk` (may prompt for password — document if it does)
 2. **Wrong active account**: `gcloud config set account michal@opsagents.agency`
-3. **Wrong active project**: `gcloud config set project opsagent-491114`
+3. **Wrong active project**: `gcloud config set project opsagent-prod`
 4. **Region unset**: `gcloud config set compute/region me-west1`
 5. **ADC missing**: `gcloud auth application-default login` (requires interactive browser — flag as manual)
-6. **API disabled**: `gcloud services enable <api-name> --project=opsagent-491114`
+6. **API disabled**: `gcloud services enable <api-name> --project=opsagent-prod`
 7. **Billing not linked**: flag as manual (requires billing account admin)
+8. **Primary account refresh token blocked** (`ERROR: Reauthentication failed. cannot prompt during non-interactive execution.`):
+   - Detection: any gcloud command for the active account returns the reauth error.
+   - Root cause: `opsagents.agency` Workspace SSO invalidates refresh tokens periodically.
+   - Auto-fix: NOT possible — requires interactive `gcloud auth login michal@opsagents.agency` + `gcloud auth application-default login`. Flag as manual in report.
+   - Partial recovery: attempt socialjetopsagent-scoped checks via `--account=socialjetopsagents@gmail.com` so the run still produces useful data.
+9. **`gcloud config set <property>` fails because the active account's refresh token is blocked** (even local property writes try to refresh the token on load):
+   - Workaround: temporarily switch to a working credentialed account, set the property, switch back:
+     ```
+     gcloud config set account msmobileapps@gmail.com     # any account with a valid token
+     gcloud config set compute/region me-west1            # the property you actually wanted to set
+     gcloud config set account michal@opsagents.agency    # restore expected active account
+     ```
+   - This unblocks region/project/zone fixes even when the primary is dead.
 
 Always save the final report regardless of pass/fail count. Document every fix attempt.
 
@@ -197,9 +210,9 @@ Always save the final report regardless of pass/fail count. Document every fix a
 
 | Account | Project | Role |
 |---------|---------|------|
-| michal@opsagents.agency | opsagent-491114 | Primary — OpsAgent core infra, Cloud Run, IAM |
-| msmobileapps@gmail.com | opsagent-491114 | Legacy billing owner — same project, org-level |
-| socialjetopsagents@gmail.com | socialjetopsagent | SocialJet ops — separate project |
+| michal@opsagents.agency | opsagent-prod | Primary — OpsAgent core infra, Cloud Run, IAM. Subject to `opsagents.agency` Workspace SSO reauth cycle. |
+| msmobileapps@gmail.com | (legacy `opsagent-491114` only) | Legacy billing owner on the old project. **No IAM on `opsagent-prod`** — do NOT use as a read fallback on the new canonical project. |
+| socialjetopsagents@gmail.com | socialjetopsagent | Active runtime project — also hosts `opsagent-core`, `opsagent-ai-runtime`, `opsagent-dashboard` Cloud Run services (not just SocialJet). |
 
 ## Cloud Run Free Tier (reference)
 - 2M requests/month free


### PR DESCRIPTION
## Summary
Auto-generated from the 2026-04-21 Cowork+DC health check run. Four new lessons surfaced; plugin updated to v3.2.0.

- **SSO reauth lesson** — `opsagents.agency` Workspace invalidates refresh tokens periodically, causing silent scheduled-run failures with `Reauthentication failed. cannot prompt during non-interactive execution.` Now step 8 in AUTO-FIX LOOP (manual fix flagged).
- **`gcloud config set <property>` workaround** — `config set` tries to refresh the active account token on load, so it fails end-to-end when the primary token is blocked. Fix: switch to a working credentialed account, set the property, switch back. Now step 9 in AUTO-FIX LOOP.
- **Stale project references** — all 14 occurrences of `opsagent-491114` in SKILL.md replaced with `opsagent-prod` (SKILL.md had drifted from the v3.0.0 CLAUDE.md).
- **Account Architecture table rewrite** — `msmobileapps@gmail.com` has no IAM on `opsagent-prod`; `socialjetopsagent` is an active OpsAgent runtime project (hosts `opsagent-core`, `opsagent-ai-runtime`, `opsagent-dashboard`) not just SocialJet ops.

## Test plan
- [ ] After Michal runs `gcloud auth login michal@opsagents.agency` + `gcloud auth application-default login`, re-run the `gcloud-cli-health-check` scheduled task.
- [ ] Verify the new step-c/region/project checks all target `opsagent-prod` (no stale `opsagent-491114` references trigger).
- [ ] Confirm the SKILL.md AUTO-FIX LOOP step 9 unblocks region fix in a future blocked-token scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code) running as Cowork scheduled task `gcloud-cli-health-check`.