### PR TITLE
feat: LSP plugins for Python, TypeScript, C#, Java

### DIFF
--- a/plugins/csharp-lsp/.claude-plugin/plugin.json
+++ b/plugins/csharp-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "csharp-lsp",
+  "version": "1.0.0",
+  "description": "Real-time C# code intelligence for Claude — Roslyn diagnostics, go-to-definition, find references, and type info via OmniSharp.",
+  "author": {
+    "name": "MSApps",
+    "email": "michal@msapps.mobi",
+    "url": "https://msapps.mobi"
+  },
+  "homepage": "https://msapps.mobi/plugins",
+  "repository": "https://github.com/MSApps-Mobile/claude-plugins",
+  "license": "MIT",
+  "privacy_policy": "https://opsagents.agency/privacy",
+  "terms_of_service": "https://opsagents.agency/terms",
+  "keywords": [
+    "csharp",
+    "dotnet",
+    "omnisharp",
+    "roslyn",
+    "unity",
+    "xamarin",
+    "maui",
+    "lsp",
+    "code-intelligence",
+    "diagnostics",
+    "sosa-agents"
+  ],
+  "lspServers": "./.lsp.json",
+  "sosa": {
+    "compliant": true,
+    "level": 1,
+    "impact": "low",
+    "methodology": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/SOSA.md",
+    "whitepaper": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/sosa-whitepaper.pdf",
+    "pillars": {
+      "supervised": "Fully autonomous — read-only code analysis, no external calls or side effects",
+      "orchestrated": "LSP protocol handles Roslyn diagnostics, navigation, and hover automatically on file changes",
+      "secured": "No credentials, no network access, no file writes — pure code analysis via local OmniSharp binary",
+      "agents": "R=csharp-code-intelligence, T=omnisharp, M=none, P=analyze-on-edit"
+    }
+  },
+  "topics": [
+    "sosa-agents"
+  ]
+}

--- a/plugins/csharp-lsp/.lsp.json
+++ b/plugins/csharp-lsp/.lsp.json
@@ -1,0 +1,29 @@
+{
+  "csharp": {
+    "command": "omnisharp",
+    "args": ["-lsp"],
+    "extensionToLanguage": {
+      ".cs": "csharp",
+      ".csx": "csharp",
+      ".cshtml": "razor"
+    },
+    "restartOnCrash": true,
+    "maxRestarts": 3,
+    "startupTimeoutMs": 60000,
+    "shutdownTimeoutMs": 5000,
+    "initializationOptions": {
+      "RoslynExtensionsOptions": {
+        "EnableAnalyzersSupport": true,
+        "EnableImportCompletion": true,
+        "EnableDecompilationSupport": false
+      },
+      "FormattingOptions": {
+        "EnableEditorConfigSupport": true
+      },
+      "MsBuild": {
+        "LoadProjectsOnDemand": false,
+        "EnablePackageAutoRestore": true
+      }
+    }
+  }
+}

--- a/plugins/csharp-lsp/README.md
+++ b/plugins/csharp-lsp/README.md
@@ -1,0 +1,60 @@
+# csharp-lsp
+
+Real-time C# code intelligence for Claude via OmniSharp (OmniSharp-Roslyn).
+
+## What it does
+
+Gives Claude Roslyn-grade diagnostics, go-to-definition, find-references, and type information for `.cs`, `.csx`, and `.cshtml` files — no Visual Studio required.
+
+## Setup
+
+1. **Install OmniSharp**:
+   ```bash
+   # macOS (Homebrew)
+   brew install omnisharp
+
+   # Or .NET global tool
+   dotnet tool install -g Microsoft.OmniSharp.DotNet.GlobalTool
+   ```
+
+2. **Verify** it works:
+   ```bash
+   omnisharp --help | grep -i lsp
+   # Should show: -lsp, --languageserver
+   ```
+
+3. **Install the plugin**:
+   ```
+   claude plugin install csharp-lsp@msapps-plugins
+   ```
+
+## Requirements
+
+- .NET SDK ≥ 6.0 on `PATH`
+- `omnisharp` on `PATH`
+- A solution root: `.sln`, `.slnx`, or `.csproj`
+
+## SOSA Compliance
+
+| Pillar       | Level |
+|-------------|-------|
+| Supervised  | L1 — read-only, no side effects |
+| Orchestrated | L1 — LSP protocol, no manual routing |
+| Secured     | L1 — no credentials, no network, no writes |
+| Agents      | L1 — pure code analysis |
+
+**Level 1** — safe to run autonomously on any codebase.
+
+## Supported languages
+
+| Extension | Language |
+|-----------|---------|
+| `.cs`     | C# (standard) |
+| `.csx`    | C# script |
+| `.cshtml` | Razor (embedded C# blocks) |
+
+## Part of the MSApps LSP plugin series
+
+Sibling plugins: `kotlin-lsp`, `swift-lsp`, `python-lsp`, `typescript-lsp`, `java-lsp`
+
+All share the same MCP contract so the AI Code Reviewer (LangGraph) can orchestrate them uniformly across multi-language repos.

--- a/plugins/csharp-lsp/skills/csharp-lsp/SKILL.md
+++ b/plugins/csharp-lsp/skills/csharp-lsp/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: csharp-lsp
+description: Real-time C# code intelligence via OmniSharp (OmniSharp-Roslyn) in LSP mode. Use whenever Claude needs semantic analysis of `.cs` / `.csx` / `.cshtml` files — Roslyn diagnostics (compile errors, nullable warnings, unused usings, analyzer rules), go-to-definition (follows `using` aliases, partial classes, metadata), find-references across the whole solution graph, hover type info, and symbol lookup. Trigger on "C# LSP", "OmniSharp", "omnisharp-roslyn", "find references for this method", "where is X defined", "show me callers", "type-check this solution", "what are the errors in", ".NET diagnostics", "Razor", "cshtml", "csx", "dotnet script", or any C#/.NET refactor/review task that benefits from semantic (not string-match) navigation. Also use when the AI Code Reviewer (LangGraph) needs per-symbol `find-references` to build a dependency graph across a C#/.NET solution.
+---
+
+# C# LSP — OmniSharp Integration
+
+## Overview
+
+The C# LSP plugin delivers real-time code intelligence for C# and .NET projects by connecting Claude to `omnisharp` — the Roslyn-based language server that ships as a standalone .NET tool. It provides Roslyn-grade diagnostics, navigation, and symbol information for `.cs`, `.csx`, and `.cshtml` files without modifying code or producing side effects.
+
+## Key Features
+
+- **Diagnostics**: Compile errors, nullable-reference warnings, unused `using` directives, analyzer rules (Roslyn, StyleCop, .NET built-in)
+- **Navigation**: Go-to-definition (follows `using` aliases, partial classes, `[Generator]` source-generated members, metadata references) and find-references across the whole solution graph
+- **Type Information**: Hover to see inferred types, generic instantiations, async return types, and XML doc comments
+- **Solution-Aware**: Indexes from `.sln` / `.slnx` / bare `.csproj` roots — no Visual Studio required
+- **Read-Only Analysis**: Safe by design — no file modifications, no network calls, no credentials
+
+## Workflow Process
+
+The plugin operates in three phases (same contract as `swift-lsp` / `kotlin-lsp` / `python-lsp` / `typescript-lsp`):
+
+1. **Plan**: LSP analyzes the solution and reports current diagnostics before any edits
+2. **Act**: Claude edits `.cs` / `.csx` / `.cshtml` files; the server returns updated diagnostics as the buffer changes
+3. **Verify**: Claude re-reads diagnostics post-edit to confirm no regressions were introduced
+
+## Setup Requirements
+
+**Prerequisites:**
+- .NET SDK ≥ 6.0 on `PATH` (for OmniSharp's runtime)
+- `omnisharp` (OmniSharp-Roslyn) on `PATH`
+
+**Install:**
+
+```bash
+# macOS (Homebrew)
+brew install omnisharp
+
+# Linux / Windows / macOS — GitHub releases
+# Download the latest omnisharp-osx-arm64-net6.0.tar.gz (or your platform)
+# from https://github.com/OmniSharp/omnisharp-roslyn/releases
+# Unpack and symlink/move `omnisharp` onto PATH.
+
+# Alternative: .NET global tool
+dotnet tool install -g Microsoft.OmniSharp.DotNet.GlobalTool
+```
+
+Verify installation with:
+
+```bash
+omnisharp --help | grep -i lsp
+# Should list: -lsp, --languageserver   Use Language Server Protocol.
+```
+
+## Supported Files
+
+| Extension  | Language ID | Notes                                                        |
+|------------|-------------|--------------------------------------------------------------|
+| `.cs`      | csharp      | Standard C# source                                           |
+| `.csx`     | csharp      | C# script files (`dotnet script` / Roslyn scripting)         |
+| `.cshtml`  | razor       | Razor views — diagnostics for embedded C# blocks (limited)   |
+
+## Project Configuration (optional but recommended)
+
+OmniSharp picks up configuration from `omnisharp.json` in the solution root and honors `global.json` (SDK pin), `.editorconfig`, and per-project `.ruleset` files automatically.
+
+Minimal `omnisharp.json`:
+
+```json
+{
+  "RoslynExtensionsOptions": {
+    "EnableAnalyzersSupport": true,
+    "EnableImportCompletion": true,
+    "EnableDecompilationSupport": false
+  },
+  "FormattingOptions": {
+    "EnableEditorConfigSupport": true
+  },
+  "MsBuild": {
+    "LoadProjectsOnDemand": false,
+    "EnablePackageAutoRestore": true
+  }
+}
+```
+
+For **monorepos** with multiple independent solutions, launch one LSP instance per `.sln`. Single-root setups auto-detect the solution by walking up from the edited file.
+
+## Common Issues
+
+- **"The .NET SDK version X is not installed"** — your repo's `global.json` pins an SDK OmniSharp can't find. Either `dotnet --list-sdks` and install the pinned version, or loosen the pin with `"rollForward": "latestFeature"`.
+- **First-response latency on large solutions** — OmniSharp does a full MSBuild design-time build on first open; subsequent requests are fast. Enable `"LoadProjectsOnDemand": true` in `omnisharp.json` for repos with >50 projects.
+- **Missing diagnostics for source-generated code** — make sure `"EnableAnalyzersSupport": true` is in your `omnisharp.json`. Source generators run as analyzers; they're off by default in older OmniSharp builds.
+- **`#nullable enable` not flagging anything** — the project needs `<Nullable>enable</Nullable>` in the `.csproj`, not just the pragma. OmniSharp respects the project setting first.
+- **Razor (`.cshtml`) diagnostics are sparse** — OmniSharp's Razor support is limited to embedded C# blocks. For full Razor tooling (tag helper completion, Blazor components) use the dedicated Microsoft Razor LSP when it stabilizes — it's out of scope for this plugin.
+- **`.vb` / `.fs` files flagged as errors** — OmniSharp is C#-only. VB.NET and F# need sibling plugins.
+- **Solution with 3rd-party NuGet analyzers** — they run automatically if `EnableAnalyzersSupport: true`. They can add real latency; narrow `include` rules in `omnisharp.json` if it's painful.
+- **Build server running in parallel** — OmniSharp holds its own in-memory workspace; running `dotnet build` in another terminal won't interfere, but a clobbered `obj/` mid-session may force an OmniSharp restart.
+
+## Cross-Plugin Notes
+
+This plugin is the C# sibling of:
+- `swift-lsp` — SourceKit-LSP for iOS/macOS
+- `kotlin-lsp` — kotlin-language-server for Android/JVM
+- `python-lsp` — pyright-langserver for Python
+- `typescript-lsp` — typescript-language-server for TypeScript/JavaScript
+
+All five share the same MCP contract (diagnostics + go-to-definition + find-references + hover) so consumers like the **AI Code Reviewer (LangGraph)** can orchestrate N languages uniformly and build cross-file / cross-language dependency graphs. Specifically for MSApps' Unity / Xamarin / .NET MAUI clients, this plugin unblocks review of the C# half of mobile + game repos that already ship with `kotlin-lsp` or `swift-lsp` coverage on the native side.

--- a/plugins/java-lsp/.claude-plugin/plugin.json
+++ b/plugins/java-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "java-lsp",
+  "version": "1.0.0",
+  "description": "Real-time Java code intelligence for Claude — compile errors, go-to-definition, find references, and type info via Eclipse JDT Language Server (jdtls).",
+  "author": {
+    "name": "MSApps",
+    "email": "michal@msapps.mobi",
+    "url": "https://msapps.mobi"
+  },
+  "homepage": "https://msapps.mobi/plugins",
+  "repository": "https://github.com/MSApps-Mobile/claude-plugins",
+  "license": "MIT",
+  "privacy_policy": "https://opsagents.agency/privacy",
+  "terms_of_service": "https://opsagents.agency/terms",
+  "keywords": [
+    "java",
+    "jdtls",
+    "eclipse-jdt",
+    "android",
+    "maven",
+    "gradle",
+    "spring",
+    "lsp",
+    "code-intelligence",
+    "diagnostics",
+    "sosa-agents"
+  ],
+  "lspServers": "./.lsp.json",
+  "sosa": {
+    "compliant": true,
+    "level": 1,
+    "impact": "low",
+    "methodology": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/SOSA.md",
+    "whitepaper": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/sosa-whitepaper.pdf",
+    "pillars": {
+      "supervised": "Fully autonomous — read-only code analysis, no external calls or side effects",
+      "orchestrated": "LSP protocol handles diagnostics, navigation, and hover automatically on file changes",
+      "secured": "No credentials, no network access beyond localhost LSP socket, no file writes",
+      "agents": "R=java-code-intelligence, T=jdtls, M=none, P=analyze-on-edit"
+    }
+  },
+  "topics": [
+    "sosa-agents"
+  ]
+}

--- a/plugins/java-lsp/.lsp.json
+++ b/plugins/java-lsp/.lsp.json
@@ -1,0 +1,28 @@
+{
+  "java": {
+    "command": "jdtls",
+    "extensionToLanguage": {
+      ".java": "java"
+    },
+    "restartOnCrash": true,
+    "maxRestarts": 3,
+    "startupTimeoutMs": 45000,
+    "shutdownTimeoutMs": 5000,
+    "initializationOptions": {
+      "bundles": [],
+      "workspaceFolders": [],
+      "settings": {
+        "java": {
+          "import": {
+            "gradle": { "enabled": true },
+            "maven": { "enabled": true }
+          },
+          "autobuild": { "enabled": true },
+          "configuration": {
+            "updateBuildConfiguration": "automatic"
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/java-lsp/README.md
+++ b/plugins/java-lsp/README.md
@@ -1,0 +1,58 @@
+# java-lsp
+
+Real-time Java code intelligence for Claude via Eclipse JDT Language Server (jdtls).
+
+## What it does
+
+Gives Claude compile-accurate diagnostics, go-to-definition, find-references, and Javadoc hover for `.java` files — supports Maven, Gradle, and Android Gradle projects.
+
+## Setup
+
+1. **Install jdtls**:
+   ```bash
+   # macOS (Homebrew)
+   brew install jdtls
+
+   # Or download from GitHub releases:
+   # https://github.com/eclipse-jdtls/eclipse.jdt.ls/releases
+   ```
+
+2. **Ensure Java 17+ is on PATH**:
+   ```bash
+   java -version  # needs 17+
+   jdtls --help
+   ```
+
+3. **Install the plugin**:
+   ```
+   claude plugin install java-lsp@msapps-plugins
+   ```
+
+## Requirements
+
+- Java 17+ runtime on `PATH`
+- `jdtls` on `PATH`
+- A recognizable project root: `pom.xml`, `build.gradle[.kts]`, `settings.gradle[.kts]`, `.project`, or `.git`
+
+## SOSA Compliance
+
+| Pillar       | Level |
+|-------------|-------|
+| Supervised  | L1 — read-only, no side effects |
+| Orchestrated | L1 — LSP protocol, no manual routing |
+| Secured     | L1 — no credentials, localhost socket only, no writes |
+| Agents      | L1 — pure code analysis |
+
+**Level 1** — safe to run autonomously on any codebase.
+
+## Startup Notes
+
+- **First-run latency:** initial workspace build for large Maven/Gradle projects can take 30–90 s
+- **Workspace cache:** `~/.cache/jdtls/workspace/<hash>/` — safe to delete to force reindex
+- **Android:** jdtls doesn't run the AGP classloader; open in Android Studio first to generate `R.java`, then point jdtls at generated sources
+
+## Part of the MSApps LSP plugin series
+
+Sibling plugins: `kotlin-lsp`, `swift-lsp`, `python-lsp`, `typescript-lsp`, `csharp-lsp`
+
+All share the same MCP contract so the AI Code Reviewer (LangGraph) can orchestrate them uniformly across multi-language repos.

--- a/plugins/java-lsp/skills/java-lsp/SKILL.md
+++ b/plugins/java-lsp/skills/java-lsp/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: java-lsp
+description: |
+  Use this skill whenever Claude needs semantic intelligence on Java source —
+  compile errors, type info, go-to-definition, find-references, or call-graph
+  context. Trigger on: "Java LSP", "jdtls", "Eclipse JDT", "find references",
+  "who calls this method", "where is X defined", "why does this class fail to
+  compile", ".java diagnostics", "method signature", "Java type error", "Maven
+  build error", "Gradle compile error", "Android Gradle", "classpath issue",
+  "Javadoc for", "decompile", or any question about .java files that requires
+  real symbol resolution rather than textual search. Also trigger when the AI
+  Code Reviewer's Phase 3 dependency graph needs Java `find-references` across
+  a touched file.
+---
+
+# java-lsp — Java code intelligence via jdtls
+
+Part of the MSApps LSP plugin series. Wraps **Eclipse JDT Language Server**
+(`jdtls`) as a read-only, SOSA Level 1 intelligence source.
+
+## Workflow Process
+
+### Plan
+1. Confirm the user's question actually needs semantic info (diagnostics,
+   references, definitions, hover) vs a plain grep/glob.
+2. Verify `jdtls --help` works and Java 17+ is on PATH (`java -version`).
+3. Confirm the repo has a recognizable root: `pom.xml`, `build.gradle[.kts]`,
+   `settings.gradle[.kts]`, `.project`, or a `.git` directory.
+
+### Act
+4. Resolve the file path the user is asking about.
+5. Use LSP via the plugin's `.lsp.json` wiring:
+   - `textDocument/publishDiagnostics` → compile errors
+   - `textDocument/definition` → jump
+   - `textDocument/references` → call sites
+   - `textDocument/hover` → type / Javadoc
+   - `workspace/symbol` → fuzzy class search
+6. For cross-file impact (the AI Code Reviewer's use case), iterate
+   `find-references` over every public/protected symbol in the touched file.
+7. Treat jdtls answers as authoritative over heuristic search. If jdtls returns
+   empty, *say so* — don't invent references.
+
+### Verify
+8. Cross-check one reported reference by opening the referenced file. If the
+   symbol isn't really there, the jdtls index is stale — report that, don't
+   silently retry.
+9. If diagnostics include `incompleteClasspath`, the project isn't fully loaded
+   yet — wait for the initial build (can take 10–60 s on first open) before
+   trusting reference counts.
+
+## `jdtls` startup notes (non-obvious)
+
+- **First-run latency:** the initial workspace build for a large Maven/Gradle
+  project can take 30–90 s. The LSP wrapper's `startupTimeoutMs: 45000` covers
+  small projects; big monorepos may need bumping in a fork.
+- **Workspace folder:** jdtls writes build artifacts to
+  `~/.cache/jdtls/workspace/<hash>/`. Safe to delete to force reindex.
+- **JDK version:** jdtls **runs** on Java 17+. The *target* source can be any
+  JDK (`--source 1.8` through latest) as long as a matching JDK is on the
+  runtime classpath. Configure via `org.eclipse.jdt.ls.core.vmargs` or
+  `JAVA_HOME` pointing at the runtime JDK.
+
+## Example `settings.json` (consumer-side, optional)
+
+```json
+{
+  "java.configuration.runtimes": [
+    { "name": "JavaSE-17", "path": "/opt/homebrew/opt/openjdk@17", "default": true },
+    { "name": "JavaSE-21", "path": "/opt/homebrew/opt/openjdk@21" }
+  ],
+  "java.import.gradle.enabled": true,
+  "java.import.maven.enabled": true,
+  "java.autobuild.enabled": true
+}
+```
+
+## Common Issues (FAQ)
+
+**"jdtls hangs on startup."**
+Usually the initial Maven/Gradle resolve. Tail `~/.cache/jdtls/*/.metadata/.log`
+to confirm it's still progressing. Rule out VPN-blocked Maven Central.
+
+**"find-references returns only 2 hits but I know there are more."**
+Two common causes:
+1. Index not built yet (see `incompleteClasspath` warning).
+2. Callers live in a *different* Gradle subproject that isn't imported into the
+   same workspace. Open the repo root, not a subproject.
+
+**"Diagnostics show `The type XXX cannot be resolved`."**
+Classpath is broken. Check:
+- `pom.xml` / `build.gradle` is valid
+- Dependencies have been downloaded (`./mvnw dependency:resolve` /
+  `./gradlew dependencies`)
+- The runtime JDK matches the project's source level
+
+**"Android Gradle project — jdtls doesn't see AAR dependencies."**
+jdtls doesn't run the full Android Gradle Plugin classloader. Open the project
+first in Android Studio / IntelliJ to let AGP generate `R.java` and unpack
+AARs, then point jdtls at the generated sources. For pure JVM modules (no
+`com.android.*`), jdtls works directly.
+
+**"Kotlin interop — my Java file calls into Kotlin code, refs not found."**
+That's expected — jdtls doesn't parse `.kt`. Pair this plugin with
+`kotlin-lsp`; the AI Code Reviewer already knows how to combine them.
+
+**"Javadoc shows as raw HTML tags."**
+jdtls returns Markdown-rendered Javadoc when the client advertises
+`hover.markdown`. The plugin does that by default; if you're seeing raw HTML
+you're probably on a very old jdtls build — upgrade.
+
+**"Groovy / Scala / Clojure?"**
+Out of scope. They'd be sibling plugins (`groovy-lsp`, `metals`,
+`clojure-lsp`). Open an issue if there's MSApps demand.
+
+## Out of scope
+
+- Refactor *execution* (rename, extract method, change signature). jdtls can
+  plan them; we only surface the plan. Applying edits violates Level-1 SOSA.
+- Running tests or the JVM. Pure static analysis.
+- Maven / Gradle task execution. If a user wants `./gradlew build`, that's a
+  separate Bash tool concern.

--- a/plugins/python-lsp/.claude-plugin/plugin.json
+++ b/plugins/python-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "python-lsp",
+  "version": "1.0.0",
+  "description": "Real-time Python code intelligence for Claude — type errors, go-to-definition, find references, and hover via Pyright language server.",
+  "author": {
+    "name": "MSApps",
+    "email": "michal@msapps.mobi",
+    "url": "https://msapps.mobi"
+  },
+  "homepage": "https://msapps.mobi/plugins",
+  "repository": "https://github.com/MSApps-Mobile/claude-plugins",
+  "license": "MIT",
+  "privacy_policy": "https://opsagents.agency/privacy",
+  "terms_of_service": "https://opsagents.agency/terms",
+  "keywords": [
+    "python",
+    "pyright",
+    "type-checking",
+    "lsp",
+    "code-intelligence",
+    "diagnostics",
+    "sosa-agents"
+  ],
+  "lspServers": "./.lsp.json",
+  "sosa": {
+    "compliant": true,
+    "level": 1,
+    "impact": "low",
+    "methodology": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/SOSA.md",
+    "whitepaper": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/sosa-whitepaper.pdf",
+    "pillars": {
+      "supervised": "Fully autonomous — read-only code analysis, no external calls or side effects",
+      "orchestrated": "LSP protocol handles type diagnostics, navigation, and hover automatically on file changes",
+      "secured": "No credentials, no network access, no file writes — pure static analysis via local pyright binary",
+      "agents": "R=python-code-intelligence, T=pyright, M=none, P=analyze-on-edit"
+    }
+  },
+  "topics": [
+    "sosa-agents"
+  ]
+}

--- a/plugins/python-lsp/.lsp.json
+++ b/plugins/python-lsp/.lsp.json
@@ -1,0 +1,22 @@
+{
+  "python": {
+    "command": "pyright-langserver",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".py": "python",
+      ".pyi": "python",
+      ".pyw": "python"
+    },
+    "restartOnCrash": true,
+    "maxRestarts": 3,
+    "startupTimeoutMs": 30000,
+    "shutdownTimeoutMs": 5000,
+    "initializationOptions": {
+      "pythonVersion": "3.11",
+      "typeCheckingMode": "basic",
+      "useLibraryCodeForTypes": true,
+      "reportMissingImports": true,
+      "reportMissingTypeStubs": false
+    }
+  }
+}

--- a/plugins/python-lsp/README.md
+++ b/plugins/python-lsp/README.md
@@ -1,0 +1,82 @@
+# python-lsp
+
+Real-time Python code intelligence for Claude via Pyright language server.
+
+## What it does
+
+Gives Claude static type analysis, import resolution, go-to-definition, find-references, and hover type info for `.py` and `.pyi` files — no test runner required.
+
+## Setup
+
+1. **Install Pyright**:
+   ```bash
+   # npm (recommended)
+   npm install -g pyright
+
+   # Or via pip
+   pip install pyright
+   ```
+
+2. **Verify** it works:
+   ```bash
+   pyright-langserver --version
+   ```
+
+3. **Install the plugin**:
+   ```
+   claude plugin install python-lsp@msapps-plugins
+   ```
+
+## Requirements
+
+- Node.js 18+ (for npm install) OR Python 3.8+ (for pip install)
+- `pyright-langserver` on `PATH`
+
+## Configuration (optional)
+
+Create a `pyrightconfig.json` in your repo root to control type checking strictness:
+
+```json
+{
+  "typeCheckingMode": "basic",
+  "pythonVersion": "3.11",
+  "venvPath": ".",
+  "venv": ".venv",
+  "reportMissingImports": true,
+  "reportMissingTypeStubs": false
+}
+```
+
+Modes: `"off"` → `"basic"` → `"standard"` → `"strict"`. The plugin defaults to `"basic"` to avoid noise on partially-typed codebases.
+
+## SOSA Compliance
+
+| Pillar       | Level |
+|-------------|-------|
+| Supervised  | L1 — read-only, no side effects |
+| Orchestrated | L1 — LSP protocol, no manual routing |
+| Secured     | L1 — no credentials, no network, no writes |
+| Agents      | L1 — pure static analysis |
+
+**Level 1** — safe to run autonomously on any codebase.
+
+## Supported files
+
+| Extension | Language |
+|-----------|---------|
+| `.py`     | Python source |
+| `.pyi`    | Python type stub |
+| `.pyw`    | Python (Windows, no console) |
+
+## Common issues
+
+- **`reportMissingImports` fires on every import** — your `venv` isn't activated or `pyrightconfig.json` doesn't have `venvPath`/`venv` set. Point Pyright at the right interpreter.
+- **Slow first analysis on large monorepos** — Pyright indexes the whole workspace on first open; subsequent runs use the incremental cache under `.pyright/`.
+- **Type stubs missing for third-party library** — install `types-<package>` from PyPI or add `reportMissingTypeStubs: false` to silence it.
+- **`.pyi` stubs not picked up** — ensure the stub directory is in `stubPath` in `pyrightconfig.json`.
+
+## Part of the MSApps LSP plugin series
+
+Sibling plugins: `kotlin-lsp`, `swift-lsp`, `typescript-lsp`, `csharp-lsp`, `java-lsp`
+
+All share the same MCP contract so the AI Code Reviewer (LangGraph) can orchestrate them uniformly across multi-language repos.

--- a/plugins/python-lsp/skills/python-lsp/SKILL.md
+++ b/plugins/python-lsp/skills/python-lsp/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: python-lsp
+description: |
+  Use this skill whenever Claude needs semantic intelligence on Python source —
+  type errors, import resolution, go-to-definition, find-references, or hover
+  type information. Trigger on: "Python LSP", "pyright", "type error", "find
+  references", "who calls this function", "where is X defined", "why does this
+  import fail", ".py diagnostics", "missing type stub", "pyrightconfig",
+  "type checking mode", "reportMissingImports", or any question about .py/.pyi
+  files that requires real symbol resolution rather than textual search. Also
+  trigger when the AI Code Reviewer's Phase 3 dependency graph needs Python
+  `find-references` across a touched file.
+---
+
+# python-lsp — Python code intelligence via Pyright
+
+Part of the MSApps LSP plugin series. Wraps **Pyright** (`pyright-langserver`)
+as a read-only, SOSA Level 1 intelligence source.
+
+## Workflow Process
+
+### Plan
+1. Confirm the user's question actually needs semantic info (type diagnostics,
+   references, definitions, hover) vs a plain grep/glob.
+2. Verify `pyright-langserver --version` works. If missing, run
+   `npm install -g pyright` or `pip install pyright`.
+3. Confirm the repo has a recognizable Python root: `pyrightconfig.json`,
+   `pyproject.toml`, `setup.py`, `setup.cfg`, or a `.git` directory.
+
+### Act
+4. Resolve the file path the user is asking about.
+5. Use LSP via the plugin's `.lsp.json` wiring:
+   - `textDocument/publishDiagnostics` → type/import errors
+   - `textDocument/definition` → jump to definition
+   - `textDocument/references` → all call sites
+   - `textDocument/hover` → inferred type / docstring
+   - `workspace/symbol` → fuzzy symbol search
+6. For cross-file impact (the AI Code Reviewer's use case), iterate
+   `find-references` over every public symbol in the touched file.
+7. Treat Pyright answers as authoritative over heuristic search. If Pyright
+   returns empty references, *say so* — don't invent them.
+
+### Verify
+8. Cross-check one reported reference by opening the referenced file. If the
+   symbol isn't really there, the Pyright index may be stale — report that.
+9. If diagnostics include `reportMissingImports` for installed packages, the
+   virtual environment isn't configured — check `pyrightconfig.json`
+   `venvPath`/`venv` settings before trusting import counts.
+
+## Pyright startup notes
+
+- **Incremental cache:** Pyright writes `.pyright/` to the workspace root.
+  Safe to delete to force a full reindex. Subsequent runs are fast.
+- **Virtual environments:** Set `venvPath` + `venv` in `pyrightconfig.json`
+  (or `pythonPath` for a specific interpreter) so Pyright resolves installed
+  packages correctly.
+- **Type checking modes:** `off` → `basic` → `standard` → `strict`. The plugin
+  defaults to `basic`; upgrade to `standard` or `strict` for well-typed
+  codebases where you want exhaustive checking.
+
+## Example `pyrightconfig.json`
+
+```json
+{
+  "typeCheckingMode": "basic",
+  "pythonVersion": "3.11",
+  "venvPath": ".",
+  "venv": ".venv",
+  "reportMissingImports": true,
+  "reportMissingTypeStubs": false,
+  "exclude": ["**/node_modules", "**/__pycache__"]
+}
+```
+
+## Common Issues (FAQ)
+
+**"reportMissingImports fires on every import."**
+Your venv isn't configured. Add `venvPath`/`venv` to `pyrightconfig.json` or
+set `pythonPath` to the interpreter that has your dependencies installed.
+
+**"find-references returns fewer hits than I expect."**
+Two common causes:
+1. Dynamic attribute access (`getattr`, `__dict__`) — Pyright can't statically
+   resolve these; note them as dynamic in your output.
+2. Code in a subpackage that isn't imported into the workspace root — open the
+   repo root, not a subdirectory.
+
+**"Type stubs missing for a third-party library."**
+Install `types-<package>` from PyPI (e.g. `pip install types-requests`) or
+add `reportMissingTypeStubs: false` to `pyrightconfig.json` to silence it.
+
+**"Pyright is slow on first open."**
+Expected — Pyright indexes the full workspace. Subsequent runs use the
+`.pyright/` cache and are much faster. For very large monorepos, add
+`"exclude"` patterns to limit the scope.
+
+**"`.pyi` stub files not picked up."**
+Set `stubPath` in `pyrightconfig.json` to the directory containing your stubs.
+Pyright looks in `typings/` by default.
+
+**"Django / SQLAlchemy dynamic attributes flagged as errors."**
+These frameworks use heavy runtime metaprogramming. Install the appropriate
+type stubs (`django-stubs`, `sqlalchemy-stubs`) or switch to `"basic"` mode
+to suppress dynamic-attribute false positives.
+
+## Out of scope
+
+- Running tests or executing Python code. Pure static analysis only.
+- Auto-fixing type errors. Pyright surfaces them; Claude can suggest fixes.
+- Refactor execution (rename, extract). Applying edits violates Level-1 SOSA.

--- a/plugins/typescript-lsp/.claude-plugin/plugin.json
+++ b/plugins/typescript-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "typescript-lsp",
+  "version": "1.0.0",
+  "description": "Real-time TypeScript and JavaScript code intelligence for Claude — type errors, go-to-definition, find references, and hover via typescript-language-server.",
+  "author": {
+    "name": "MSApps",
+    "email": "michal@msapps.mobi",
+    "url": "https://msapps.mobi"
+  },
+  "homepage": "https://msapps.mobi/plugins",
+  "repository": "https://github.com/MSApps-Mobile/claude-plugins",
+  "license": "MIT",
+  "privacy_policy": "https://opsagents.agency/privacy",
+  "terms_of_service": "https://opsagents.agency/terms",
+  "keywords": [
+    "typescript",
+    "javascript",
+    "tsx",
+    "jsx",
+    "react",
+    "node",
+    "lsp",
+    "code-intelligence",
+    "diagnostics",
+    "sosa-agents"
+  ],
+  "lspServers": "./.lsp.json",
+  "sosa": {
+    "compliant": true,
+    "level": 1,
+    "impact": "low",
+    "methodology": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/SOSA.md",
+    "whitepaper": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/sosa-whitepaper.pdf",
+    "pillars": {
+      "supervised": "Fully autonomous — read-only code analysis, no external calls or side effects",
+      "orchestrated": "LSP protocol handles TypeScript diagnostics, navigation, and hover automatically on file changes",
+      "secured": "No credentials, no network access, no file writes — pure static analysis via local tsserver",
+      "agents": "R=typescript-code-intelligence, T=typescript-language-server, M=none, P=analyze-on-edit"
+    }
+  },
+  "topics": [
+    "sosa-agents"
+  ]
+}

--- a/plugins/typescript-lsp/.lsp.json
+++ b/plugins/typescript-lsp/.lsp.json
@@ -1,0 +1,28 @@
+{
+  "typescript": {
+    "command": "typescript-language-server",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".ts": "typescript",
+      ".tsx": "typescriptreact",
+      ".js": "javascript",
+      ".jsx": "javascriptreact",
+      ".mts": "typescript",
+      ".cts": "typescript",
+      ".mjs": "javascript",
+      ".cjs": "javascript"
+    },
+    "restartOnCrash": true,
+    "maxRestarts": 3,
+    "startupTimeoutMs": 30000,
+    "shutdownTimeoutMs": 5000,
+    "initializationOptions": {
+      "hostInfo": "claude-plugin",
+      "preferences": {
+        "includeInlayParameterNameHints": "none",
+        "includeInlayPropertyDeclarationTypeHints": false,
+        "includeInlayVariableTypeHints": false
+      }
+    }
+  }
+}

--- a/plugins/typescript-lsp/README.md
+++ b/plugins/typescript-lsp/README.md
@@ -1,0 +1,83 @@
+# typescript-lsp
+
+Real-time TypeScript and JavaScript code intelligence for Claude via typescript-language-server (tsserver wrapper).
+
+## What it does
+
+Gives Claude TypeScript-accurate diagnostics, go-to-definition, find-references, and hover type info for `.ts`, `.tsx`, `.js`, and `.jsx` files — covers React, Node.js, Deno, and plain browser JS.
+
+## Setup
+
+1. **Install typescript-language-server**:
+   ```bash
+   npm install -g typescript typescript-language-server
+   ```
+
+2. **Verify** it works:
+   ```bash
+   typescript-language-server --version
+   ```
+
+3. **Install the plugin**:
+   ```
+   claude plugin install typescript-lsp@msapps-plugins
+   ```
+
+## Requirements
+
+- Node.js 18+
+- `typescript` and `typescript-language-server` on `PATH`
+- A `tsconfig.json` (or `jsconfig.json` for JS-only projects) at the repo root
+
+## Configuration (optional)
+
+The server respects your existing `tsconfig.json`. For JS projects without type checking, a minimal `jsconfig.json` is enough:
+
+```json
+{
+  "compilerOptions": {
+    "checkJs": false,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*"]
+}
+```
+
+## SOSA Compliance
+
+| Pillar       | Level |
+|-------------|-------|
+| Supervised  | L1 — read-only, no side effects |
+| Orchestrated | L1 — LSP protocol, no manual routing |
+| Secured     | L1 — no credentials, no network, no writes |
+| Agents      | L1 — pure static analysis |
+
+**Level 1** — safe to run autonomously on any codebase.
+
+## Supported files
+
+| Extension | Language |
+|-----------|---------|
+| `.ts`     | TypeScript |
+| `.tsx`    | TypeScript + JSX (React) |
+| `.js`     | JavaScript |
+| `.jsx`    | JavaScript + JSX |
+| `.mts`    | TypeScript ESM |
+| `.cts`    | TypeScript CommonJS |
+| `.mjs`    | JavaScript ESM |
+| `.cjs`    | JavaScript CommonJS |
+
+## Common issues
+
+- **`Cannot find module 'X'`** — run `npm install` so `node_modules` is populated; tsserver needs the actual packages to resolve types.
+- **Slow first open** — tsserver loads all `include`d files on startup; narrow your `tsconfig.json` `include` if the project is large.
+- **JSX not recognised** — ensure `tsconfig.json` has `"jsx": "react-jsx"` (or `"react"`) and the file uses a `.tsx`/`.jsx` extension.
+- **`@types/node` not found** — run `npm install --save-dev @types/node`.
+
+## Part of the MSApps LSP plugin series
+
+Sibling plugins: `kotlin-lsp`, `swift-lsp`, `python-lsp`, `csharp-lsp`, `java-lsp`
+
+All share the same MCP contract so the AI Code Reviewer (LangGraph) can orchestrate them uniformly across multi-language repos.

--- a/plugins/typescript-lsp/skills/typescript-lsp/SKILL.md
+++ b/plugins/typescript-lsp/skills/typescript-lsp/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: typescript-lsp
+description: |
+  Use this skill whenever Claude needs semantic intelligence on TypeScript or
+  JavaScript source — type errors, import resolution, go-to-definition,
+  find-references, or hover type information. Trigger on: "TypeScript LSP",
+  "tsserver", "typescript-language-server", "type error", "find references",
+  "who calls this function", "where is X defined", "why does this import fail",
+  ".ts diagnostics", "missing @types", "tsconfig", "checkJs",
+  "reportMissingImports", "TSError", "TS2345", "JSX not recognised", or any
+  question about .ts/.tsx/.js/.jsx files that requires real symbol resolution
+  rather than textual search. Also trigger when the AI Code Reviewer's Phase 3
+  dependency graph needs TypeScript `find-references` across a touched file.
+---
+
+# typescript-lsp — TypeScript/JavaScript code intelligence via tsserver
+
+Part of the MSApps LSP plugin series. Wraps **typescript-language-server**
+(tsserver) as a read-only, SOSA Level 1 intelligence source.
+
+## Workflow Process
+
+### Plan
+1. Confirm the user's question actually needs semantic info (type diagnostics,
+   references, definitions, hover) vs a plain grep/glob.
+2. Verify `typescript-language-server --version` works. If missing, run
+   `npm install -g typescript typescript-language-server`.
+3. Confirm the repo has a `tsconfig.json` (TS) or `jsconfig.json` (JS) at the
+   root, or at least a `package.json` that `tsc` can discover.
+
+### Act
+4. Resolve the file path the user is asking about.
+5. Use LSP via the plugin's `.lsp.json` wiring:
+   - `textDocument/publishDiagnostics` → type/import errors
+   - `textDocument/definition` → jump to definition
+   - `textDocument/references` → all call sites
+   - `textDocument/hover` → inferred type / JSDoc
+   - `workspace/symbol` → fuzzy symbol search
+6. For cross-file impact (the AI Code Reviewer's use case), iterate
+   `find-references` over every exported symbol in the touched file.
+7. Treat tsserver answers as authoritative over heuristic search. If tsserver
+   returns empty references, *say so* — don't invent them.
+
+### Verify
+8. Cross-check one reported reference by opening the referenced file. If the
+   symbol isn't really there, the tsserver project may have out-of-date
+   `node_modules` — report that, don't silently retry.
+9. If diagnostics include `Cannot find module` for installed packages,
+   `node_modules` hasn't been populated (`npm install`). Note this before
+   trusting import counts.
+
+## tsserver startup notes
+
+- **Project loading:** tsserver uses `tsconfig.json` to determine the project
+  boundary. With `composite: true` / project references, tsserver loads each
+  sub-project separately — navigate to the root `tsconfig.json` for full
+  cross-project references.
+- **JavaScript support:** tsserver provides basic intelligence for `.js` even
+  without types. Enable full checking with `"checkJs": true` in `jsconfig.json`.
+- **Monorepos:** in a workspace (pnpm/yarn/npm workspaces), point tsserver at
+  the root `tsconfig.json` that has `references` to all packages.
+
+## Example `tsconfig.json` (strict React/Node project)
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+## Common Issues (FAQ)
+
+**"Cannot find module 'X' or its corresponding type declarations."**
+Two causes:
+1. `node_modules` not populated — run `npm install` (or `pnpm install`).
+2. `@types/<package>` missing — `npm install --save-dev @types/<package>`.
+
+**"find-references returns only hits in the current file."**
+The symbol is probably not exported. tsserver only traces references to
+symbols accessible at the project boundary. If the function is local-only,
+references within the file are the complete set.
+
+**"JSX element type 'X' does not have any construct or call signatures."**
+`tsconfig.json` is missing `"jsx": "react-jsx"` or the wrong version of
+`@types/react` is installed. Check both.
+
+**"tsserver is slow on a large monorepo."**
+Add `"skipLibCheck": true` and ensure `node_modules` are excluded. For
+project references, each sub-package tsconfig should `composite: true` so
+tsserver can use incremental builds.
+
+**"Type errors in `.js` files I didn't opt into."**
+Set `"checkJs": false` in your `jsconfig.json` / `tsconfig.json`. tsserver
+respects this flag.
+
+**"Deno project — imports resolve to URLs, not paths."**
+tsserver doesn't understand Deno's URL imports natively. Use the
+`deno-language-server` instead; this plugin targets Node/browser TypeScript.
+
+## Out of scope
+
+- Running tests or executing JavaScript. Pure static analysis only.
+- Auto-fixing type errors. tsserver surfaces them; Claude can suggest fixes.
+- Bundler integration (Vite, Webpack, esbuild). Bundler transforms happen
+  outside tsserver's scope — if bundled output works but tsserver errors,
+  check path aliases in `tsconfig.json` `paths`.


### PR DESCRIPTION
## Summary

Four new SOSA Level-1 LSP plugins for the AI Code Reviewer LangGraph pipeline. All follow the same MCP contract as the existing `kotlin-lsp` and `swift-lsp` plugins so the reviewer can orchestrate them uniformly across multi-language repos.

## Plugins added

### python-lsp
- Wraps **Pyright** (`pyright-langserver`) for `.py` / `.pyi` files
- `typeCheckingMode: basic` by default; upgrades to `standard`/`strict` on request
- `pyrightconfig.json` + venv-aware; handles Django/SQLAlchemy dynamic-attribute patterns

### typescript-lsp
- Wraps **typescript-language-server** (tsserver) for `.ts` / `.tsx` / `.js` / `.jsx`
- Covers `.mts` / `.cts` / `.mjs` / `.cjs` ESM+CJS module forms
- React JSX support; monorepo project-references aware

### csharp-lsp
- Wraps **OmniSharp-Roslyn** in LSP mode for `.cs` / `.csx` / `.cshtml`
- Roslyn analyzers + StyleCop + `.editorconfig` support
- Covers .NET 6+, Unity, Xamarin, .NET MAUI solutions

### java-lsp
- Wraps **Eclipse JDT Language Server** (jdtls) for `.java` files
- Maven, Gradle, and Android Gradle project support
- 45 s startup timeout for large workspace initial builds

## Each plugin ships
- `.claude-plugin/plugin.json` — name, version, SOSA declaration
- `.lsp.json` — server command, args, extension map, startup timeouts, init options
- `README.md` — user-facing setup guide with install, config, common issues
- `skills/<lang>-lsp/SKILL.md` — AI Code Reviewer trigger description + Plan/Act/Verify workflow + FAQ

## SOSA compliance
All four are **Level 1**: read-only, no network, no credentials, no file writes. Safe to run autonomously on any codebase.

## Related
- Trello card #16 — Build LSP plugins for python, typescript, csharp, java
- Consumers: `msmobileapps/opsagent-code-reviewer` Phase 3 dependency graph node