### PR TITLE
opsagent-shopify v0.3.2: board-, repo-, and store-agnostic

### DIFF
--- a/plugins/opsagent-shopify/.claude-plugin/plugin.json
+++ b/plugins/opsagent-shopify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "opsagent-shopify",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "MSApps OpsAgents Shopify plugin — full Admin API + Storefront MCP tools (products CRUD, files, orders, customers, themes, metafields), go-to-market guidance, and @opsagents/shopify-sdk typed contracts.",
   "author": {
     "name": "Michal Shatz / MSApps",

--- a/plugins/opsagent-shopify/skills/shopify-mcp/SKILL.md
+++ b/plugins/opsagent-shopify/skills/shopify-mcp/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: shopify-mcp
+description: >
+  Use Shopify Storefront MCP tools to search catalogs, inspect products, read
+  and mutate carts, fetch policies, and describe shops across any MSApps /
+  OpsAgents client store — multi-tenant, no shop hardcoded. Trigger on:
+  "shopify", "storefront", "myshopify", "cart", "checkout", "products",
+  "catalog", "collection", "shipping policy", "refund policy", "client store",
+  "merchant", or any task that needs live data from a Shopify merchant. Also
+  use when the user wants to prototype a conversational shopping flow, a
+  recommendation agent, or a customer-support bot over a Shopify store.
+---
+
+# Shopify MCP — multi-tenant storefront operator
+
+Use this skill whenever Claude needs to act on a Shopify store through the
+`opsagent-shopify` MCP server. Prefer these tools over raw `fetch` calls or
+the generic `apify-scraping` skill — they are tokened, rate-aware, and
+multi-tenant.
+
+## When to trigger
+
+- "What's in `<client-handle>`'s catalog right now?"
+- "Find products in shop X under $50 that contain 'linen'."
+- "Build me a cart with three of variant ID ..."
+- "Read the shipping policy of `foo.myshopify.com`."
+- "Describe the storefront of this shop before we swap the theme."
+- "Why is `selectModel()` returning undefined on the product page of `<shop>`?"
+  → call `shopify_describe_theme` first to confirm which theme + version is
+  live before diving into theme JS.
+
+## Mental model
+
+**One install, every store.** Each tool takes an optional `shop` argument of
+the form `<handle>.myshopify.com`. If omitted, the server falls back to
+`SHOPIFY_DEFAULT_SHOP` (set per-client in the MCP config). Never hardcode a
+shop inside the skill — pass it explicitly when the user mentions one.
+
+**Two backends, one surface:**
+- Public catalog + cart ops go to Shopify's **Storefront MCP** endpoint
+  (`https://{shop}/api/mcp`). No token. Tools: `shopify_search_products`,
+  `shopify_get_cart`, `shopify_update_cart`.
+- Richer read ops (products by handle, policies, collections, shop metadata)
+  go to **Storefront GraphQL**. Needs `SHOPIFY_STOREFRONT_TOKEN`.
+
+If a GraphQL tool errors with "Storefront GraphQL requires a token," surface
+that to the user and ask them to paste one into the plugin config — don't
+silently degrade.
+
+## Plan → Act → Verify
+
+1. **Plan** — Identify the shop and the intent (read vs cart-mutation vs
+   checkout-mutation). Read ops are cheap; cart mutations should be confirmed
+   with the user if the cart is real (not a throwaway test cart).
+2. **Act** — Call the narrowest tool. Prefer `shopify_search_products` over
+   pulling the whole catalog. Prefer `shopify_get_product` for detail pages.
+3. **Verify** — For cart mutations, re-fetch with `shopify_get_cart` and show
+   the resulting line items. For checkout starts, return the URL and tell the
+   user what will happen if they open it.
+
+## Tools at a glance
+
+| Tool | Class | Token? | Purpose |
+| --- | --- | --- | --- |
+| `shopify_search_products` | read | no  | Search catalog by free text. |
+| `shopify_get_product` | read | yes | Product detail by handle. |
+| `shopify_get_cart` | read | no  | Cart state by ID. |
+| `shopify_update_cart` | cart-mutation | no | Create/add/update/remove lines. |
+| `shopify_get_policies` | read | yes | Shipping / refund / privacy / terms. |
+| `shopify_list_collections` | read | yes | Category pages. |
+| `shopify_describe_theme` | read | yes | Shop + brand + domain metadata. |
+
+## Failure modes to watch
+
+- **No shop configured** → "No shop configured. Pass `shop` argument or set
+  SHOPIFY_DEFAULT_SHOP." Ask the user which store, don't guess.
+- **Invalid domain format** → reject anything that isn't
+  `<handle>.myshopify.com`. Custom vanity domains (e.g. `<brand>.com`) need
+  to be resolved to their `myshopify.com` canonical form first.
+- **GraphQL 401/403** → Storefront token expired or scoped too narrow.
+  Regenerate in Admin → Sales channels → Headless.
+- **Rate limits** → Storefront API allows ~60 RPM per shop. If bursting,
+  chunk and backoff; never retry blindly.
+
+## Handoff to related skills
+
+- For theme changes (Symmetry install, customizing Liquid), invoke the
+  `symmetry-install` skill in this same plugin.
+- For Liquid code edits, defer to the `shopify-liquid` reference skill.
+- For the app side (OAuth install on a merchant's admin, webhook
+  registration), the `opsagent-shopify-mcp` repo README has the CLI flow.
+
+## SOSA notes
+
+- **Supervised** — cart and checkout mutations must be confirmed with the
+  user when they touch a real customer cart. Read ops are unsupervised.
+- **Secured** — the Storefront token is sensitive and per-shop; never log it
+  or include it in tool outputs.
+- **Agents** — this skill owns Shopify-facing data ops only. It does NOT
+  touch theme files, Liquid, billing, or Partner API — those are other
+  skills or the Admin API (not this server).

--- a/plugins/opsagent-shopify/skills/symmetry-install/SKILL.md
+++ b/plugins/opsagent-shopify/skills/symmetry-install/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: symmetry-install
+description: >
+  Walk a merchant through installing the Symmetry theme — or any paid Theme
+  Store theme — on any Shopify store, from Theme Store preview to live
+  publish. Trigger on: "install Symmetry", "add Symmetry theme", "install a
+  Shopify theme", "switch theme", "try a new theme", "publish a theme",
+  "Shopify theme install", "theme store", or any request to change a Shopify
+  storefront theme. Also trigger when the user links to
+  themes.shopify.com/themes/symmetry or to any Shopify Theme Store listing.
+---
+
+# Symmetry theme install — merchant playbook
+
+Use this skill when the user wants Symmetry (a paid Shopify theme by Clean
+Canvas) installed on a Shopify store. Works identically for any paid Theme
+Store theme — just swap "Symmetry" for the theme name.
+
+## What you are doing
+
+Adding a theme to a Shopify store does NOT replace the live storefront. It
+lands as a **Draft theme**, which the merchant can customize and preview at
+a secret URL. Only a deliberate "Publish" swap makes it live. The
+`shopify_describe_theme` MCP tool (from the `shopify-mcp` skill) can confirm
+what's currently published before and after.
+
+Symmetry costs money (one-time license, typically ~$350 USD, per-store).
+"Try theme" is free and creates the Draft; "Buy theme" is the licensing step.
+
+## Path A — Merchant self-serve (recommended)
+
+This is the default. The merchant owns the Shopify admin and their own
+payment method. Claude's job is to write the steps clearly.
+
+1. **Admin → Online Store → Themes.** If there is no Themes menu, the store
+   is not on a plan that permits theme changes — flag that and stop.
+2. Scroll to **Theme library** → **Add theme** → **Visit Theme Store**.
+3. Search **Symmetry** (or paste the Theme Store URL). Open the listing.
+4. Click **Try theme**. Shopify installs it in **Draft themes** for free.
+5. Customize Draft → preview with the eye icon → share preview link with
+   stakeholders.
+6. When ready, in Draft themes click the **...** menu → **Publish**.
+7. Shopify prompts for payment. Once paid, the theme becomes the live one
+   and the previous theme moves to the Theme library as a backup.
+
+> **Always recommend step 4 (Try theme) before step 7 (Buy/Publish).** A
+> Draft install is free and reversible; publishing is an immediate swap.
+
+## Path B — Partner / staff — via Shopify CLI
+
+Use this when Claude has repo access and the merchant wants a version-
+controlled theme.
+
+```bash
+# One-time: install CLI
+npm install -g @shopify/cli @shopify/theme
+
+# Auth against the merchant's store (substitute the client's handle)
+shopify login --store <handle>.myshopify.com
+
+# Pull the current live theme as a safety backup (writes to ./backup/)
+shopify theme pull --live --path ./backup
+
+# Download Symmetry source (merchant must have purchased it first — CLI cannot
+# buy a theme). Get the .zip from Theme Store > My themes, then:
+shopify theme push --path ./symmetry --unpublished
+
+# Preview
+shopify theme dev --store <handle>.myshopify.com --theme "Symmetry"
+
+# Publish when stakeholders approve
+shopify theme publish --theme "Symmetry"
+```
+
+Keep the pre-Symmetry backup in git under `themes/pre-symmetry/` so a
+rollback is `shopify theme push --path ./themes/pre-symmetry --live`.
+
+## Path C — Claude-in-Chrome automation
+
+Only use this if the user explicitly asks Claude to drive the admin. Chrome
+MCP is tier-"read" for the browser itself, but the extension tools can click
+inside the admin. Before any click inside Shopify admin:
+
+1. Verify the extension is connected (`chrome-health-check` skill).
+2. Navigate to `https://admin.shopify.com/store/<handle>/themes`.
+3. Walk the user through Try theme as above, pausing at every destructive
+   step (especially Publish) for confirmation.
+
+Do NOT auto-publish. Do NOT enter payment details. Always hand control
+back for the buy-theme step.
+
+## Pre-install checklist
+
+Before the merchant clicks anything:
+
+- [ ] Confirm current theme name and version (`shopify_describe_theme`).
+- [ ] Confirm Shopify plan supports theme changes (Basic and up do).
+- [ ] Confirm staff account has **Themes** permission.
+- [ ] Export a backup of the current theme (Admin → Themes → ... → Download).
+- [ ] Note any custom Liquid or apps that inject into the current theme —
+      these will need to be re-wired in Symmetry.
+- [ ] Screenshot the live storefront hero + product page for before/after.
+
+## Post-install checklist
+
+- [ ] Core pages render: home, collection, product, cart, search, 404.
+- [ ] Checkout flow completes end to end on a test order.
+- [ ] Apps that inject into theme still work (reviews, currency switcher,
+      cookie banner, live chat).
+- [ ] Analytics pixels present (GA4, Meta, TikTok if used).
+- [ ] Mobile viewport tested — Symmetry is responsive but custom sections
+      can break.
+- [ ] Search indexing: robots.txt and sitemap still valid.
+
+## SOSA notes
+
+- **Supervised** — publishing a theme is a destructive storefront change;
+  always confirm with the merchant before Path B's `theme publish` or
+  Path A's Publish click.
+- **Orchestrated** — follow the Plan/Act/Verify structure: describe current
+  theme, install draft, verify preview, publish, verify live.
+- **Secured** — never ask the merchant for their Shopify password. All
+  operations go through staff accounts or CLI tokens the merchant owns.


### PR DESCRIPTION
## What

Makes the `opsagent-shopify` plugin reusable across any client store with no edits.

## Changes

- **`.claude-plugin/plugin.json`** — bump `0.3.1` -> `0.3.2`; description now flags multi-tenant / no-shop-hardcoded design.
- **`skills/shopify-mcp/SKILL.md`** — added (was previously rpm-distribution-only). Strips 'Mama Sally' from triggers and example prompts; uses `<client-handle>` in placeholders. Adds a theme-JS debug trigger (e.g. `selectModel()` returning undefined) routing through `shopify_describe_theme` first.
- **`skills/symmetry-install/SKILL.md`** — added. Generic theme-install playbook (Symmetry + any paid Theme Store theme); CLI snippets use `<handle>.myshopify.com` instead of a hardcoded shop.

## Why

MSApps adds Shopify clients regularly. Hardcoding 'Mama Sally' in skill triggers + CLI examples meant every new client store needed a plugin fork. Now: pass the `shop` arg or set `SHOPIFY_DEFAULT_SHOP` per install — same plugin everywhere.

## Test plan

- Install the plugin in Cowork.
- Trigger shopify-mcp with a non-Mama-Sally store handle — verify it picks up the right shop.
- Trigger symmetry-install with any theme name — verify CLI snippet prompts for `<handle>`.

Follow-up (not in this PR): clean the lone `mama-sally.myshopify.com` example comments in `mcp-server/src/server.ts:54` and `mcp-server/src/storefront.ts:11` — non-functional but worth scrubbing.