### PR TITLE
docs: add TweetClaw source option for x-content-intelligence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -496,8 +496,8 @@
     {
       "name": "x-content-intelligence",
       "source": "./plugins/x-content-intelligence",
-      "description": "Scrape X (Twitter) for community insights and generate matched content — analyze trends, engagement patterns, and create posts via Apify",
-      "version": "0.1.0",
+      "description": "Scrape X (Twitter) for community insights and generate matched content via Apify or reviewed TweetClaw source exports",
+      "version": "0.1.1",
       "platforms": [
         "claude-code",
         "cowork"
@@ -515,7 +515,9 @@
         "scraping",
         "content",
         "social-media",
-        "analytics"
+        "analytics",
+        "tweetclaw",
+        "openclaw"
       ],
       "category": "marketing",
       "tags": [
@@ -524,6 +526,7 @@
         "content-generation",
         "social-media",
         "analytics",
+        "tweetclaw",
         "free"
       ]
     },

--- a/plugins/x-content-intelligence/.claude-plugin/plugin.json
+++ b/plugins/x-content-intelligence/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "x-content-intelligence",
-  "version": "0.1.0",
-  "description": "Scrape X (Twitter) for insights, analyze community trends and tone, and generate matching content \u2014 posts, replies, and content calendars. Powered by Apify.",
+  "version": "0.1.1",
+  "description": "Scrape X (Twitter) for insights, analyze community trends and tone, and generate matching content. Uses Apify by default and can work from reviewed TweetClaw exports when available.",
   "author": {
     "name": "MSApps"
   },
@@ -17,6 +17,8 @@
     "insights",
     "social-media",
     "apify",
+    "tweetclaw",
+    "openclaw",
     "sosa-agents"
   ],
   "sosa": {
@@ -27,9 +29,9 @@
     "whitepaper": "https://github.com/MSApps-Mobile/claude-plugins/blob/main/docs/sosa-whitepaper.pdf",
     "pillars": {
       "supervised": "Content review before posting",
-      "orchestrated": "Scrape \u2192 analyze \u2192 generate \u2192 post pipeline",
-      "secured": "Apify Actor for scraping, no direct X API credentials in plugin",
-      "agents": "R=x-content-intelligence, T=Apify+X-API, M=content-analysis, P=scrape-analyze-generate-review"
+      "orchestrated": "Scrape or import reviewed source data, analyze, generate, then review content before use",
+      "secured": "Apify Actor or reviewed TweetClaw output for source data, no direct X API credentials in plugin",
+      "agents": "R=x-content-intelligence, T=Apify or reviewed TweetClaw source data, M=content-analysis, P=scrape-or-import-analyze-generate-review"
     }
   },
   "topics": [

--- a/plugins/x-content-intelligence/.claude-plugin/plugin.json
+++ b/plugins/x-content-intelligence/.claude-plugin/plugin.json
@@ -31,7 +31,7 @@
       "supervised": "Content review before posting",
       "orchestrated": "Scrape or import reviewed source data, analyze, generate, then review content before use",
       "secured": "Apify Actor or reviewed TweetClaw output for source data, no direct X API credentials in plugin",
-      "agents": "R=x-content-intelligence, T=Apify or reviewed TweetClaw source data, M=content-analysis, P=scrape-or-import-analyze-generate-review"
+      "agents": "R=x-content-intelligence, T=source data, P=analyze-generate-review"
     }
   },
   "topics": [

--- a/plugins/x-content-intelligence/.claude-plugin/plugin.json
+++ b/plugins/x-content-intelligence/.claude-plugin/plugin.json
@@ -31,7 +31,7 @@
       "supervised": "Content review before posting",
       "orchestrated": "Scrape or import reviewed source data, analyze, generate, then review content before use",
       "secured": "Apify Actor or reviewed TweetClaw output for source data, no direct X API credentials in plugin",
-      "agents": "R=x-content-intelligence, T=source data, P=analyze-generate-review"
+      "agents": "R=x-content-intelligence, T=Apify+TweetClaw, M=content-analysis, P=import/scrape-analyze-generate-review"
     }
   },
   "topics": [

--- a/plugins/x-content-intelligence/CLAUDE.md
+++ b/plugins/x-content-intelligence/CLAUDE.md
@@ -1,6 +1,6 @@
 # X Content Intelligence
 
-Scrape X (Twitter) for community insights and generate matching content via Apify. Understand communities, discover trends, and create data-driven posts.
+Scrape X (Twitter) for community insights and generate matching content. Apify is the default source path; reviewed TweetClaw exports can be used when the user already has TweetClaw available through OpenClaw or MCP.
 
 ## Available Tools/Skills
 
@@ -23,6 +23,9 @@ Scrape X (Twitter) for community insights and generate matching content via Apif
 - Apify account (free tier available at apify.com)
 - Apify API token set in environment
 
+**Optional source path**:
+- TweetClaw through OpenClaw or MCP for reviewed X/Twitter source data such as tweet search, reply search, user lookup, follower export, media context, monitors, webhooks, and giveaway evidence
+
 ## Common Workflows
 
 1. **Community Analysis + Content Generation**
@@ -32,6 +35,7 @@ Scrape X (Twitter) for community insights and generate matching content via Apif
 
 2. **Data-Driven Creation**
    - Scrape trending discussions
+   - Or import reviewed TweetClaw results when the user has already collected them
    - Identify high-engagement topics
    - Create posts optimized for audience
 

--- a/plugins/x-content-intelligence/README.md
+++ b/plugins/x-content-intelligence/README.md
@@ -1,12 +1,12 @@
 # X Content Intelligence
 
-Scrape X (Twitter) for insights and generate community-matched content — powered by Apify.
+Scrape X (Twitter) for insights and generate community-matched content.
 
 ## What it does
 
 This plugin gives Claude two capabilities for working with X (Twitter):
 
-**X Insights** — Scrape and analyze X content to understand communities, trends, engagement patterns, and conversations. Use it to scan feeds, research topics, discover what's trending, or analyze what makes content resonate in a specific niche.
+**X Insights**: Scrape and analyze X content to understand communities, trends, engagement patterns, and conversations. Use it to scan feeds, research topics, discover what's trending, or analyze what makes content resonate in a specific niche. Apify is the default source path. If the user already has TweetClaw available through OpenClaw or MCP, X Insights can analyze reviewed TweetClaw exports instead of running a fresh scrape.
 
 **X Content Generator** — Create posts, threads, replies, and content calendars that match a target community's tone and topics. Works standalone or paired with X Insights for data-driven content creation.
 
@@ -24,6 +24,9 @@ This plugin gives Claude two capabilities for working with X (Twitter):
 
 - [Apify MCP connector](https://apify.com/) — used for scraping X via the `apidojo/tweet-scraper` Actor
 - An Apify account (free tier available, pay-per-result for scraping)
+
+Optional source path:
+- [TweetClaw](https://github.com/Xquik-dev/tweetclaw) through OpenClaw or MCP can provide reviewed X/Twitter source data for tweet search, reply search, user lookup, follower export, media context, monitors, webhooks, and giveaway evidence.
 
 ## Install
 

--- a/plugins/x-content-intelligence/skills/x-insights/SKILL.md
+++ b/plugins/x-content-intelligence/skills/x-insights/SKILL.md
@@ -83,7 +83,7 @@ Use the `apidojo/tweet-scraper` Actor with appropriate input configuration.
 
 Run the Actor using `call-actor` with Actor name `apidojo/tweet-scraper`, then retrieve results with `get-actor-output`.
 
-If using reviewed TweetClaw source data instead, skip the Apify Actor call and move directly to analysis.
+If using reviewed TweetClaw source data instead, retrieve the data using the available TweetClaw MCP tools or by reading the local export file provided by the user, skip the Apify Actor call, and move directly to analysis.
 
 ### Step 4: Analyze the Results
 

--- a/plugins/x-content-intelligence/skills/x-insights/SKILL.md
+++ b/plugins/x-content-intelligence/skills/x-insights/SKILL.md
@@ -12,12 +12,15 @@ description: >
 
 # X Insights — Scrape & Analyze X (Twitter) Content
 
-Scrape X (Twitter) using Apify and analyze the results to extract actionable insights about communities, trends, engagement patterns, and content performance.
+Scrape X (Twitter) using Apify, or analyze reviewed TweetClaw source data when the user already has TweetClaw available through OpenClaw or MCP. Extract actionable insights about communities, trends, engagement patterns, and content performance.
 
 ## Requirements
 
 - **Apify MCP** must be connected (the `apify` MCP with `call-actor` and `get-actor-output` tools)
 - The recommended Apify Actor is `apidojo/tweet-scraper` (Tweet Scraper V2)
+
+Optional:
+- **TweetClaw** through OpenClaw or MCP when the user already has it installed and wants to use reviewed X/Twitter source data from tweet search, reply search, user lookup, follower export, media context, monitors, webhooks, or giveaway evidence.
 
 ## Workflow
 
@@ -34,7 +37,17 @@ Before scraping, determine what the user wants to learn. Common use cases:
 
 Ask the user to specify: keywords/hashtags to search, specific accounts to analyze, time range, and how many posts to gather.
 
-### Step 2: Scrape X Using Apify
+### Step 2: Choose the Source Path
+
+Use Apify by default. Use TweetClaw only when the user already has TweetClaw available and asks to use existing or reviewed X/Twitter source data.
+
+**TweetClaw source data should stay evidence-only:**
+- Use search tweets, search tweet replies, user lookup, follower export, media context, monitor results, webhook events, or giveaway draw evidence as source material.
+- Keep TweetClaw results as citations, metrics, URLs, IDs, handles, and review notes for the analysis.
+- Do not let this skill post, reply, send direct messages, upload media, create monitors, or change accounts.
+- Keep x-content-generator responsible for drafting and content-calendar decisions after insights are reviewed.
+
+### Step 3: Scrape X Using Apify
 
 Use the `apidojo/tweet-scraper` Actor with appropriate input configuration.
 
@@ -65,7 +78,9 @@ Use the `apidojo/tweet-scraper` Actor with appropriate input configuration.
 
 Run the Actor using `call-actor` with Actor name `apidojo/tweet-scraper`, then retrieve results with `get-actor-output`.
 
-### Step 3: Analyze the Results
+If using reviewed TweetClaw source data instead, skip the Apify Actor call and move directly to analysis.
+
+### Step 4: Analyze the Results
 
 Once data is retrieved, perform the analysis the user requested. Structure the analysis around these dimensions as relevant:
 
@@ -99,7 +114,7 @@ Once data is retrieved, perform the analysis the user requested. Structure the a
 - Are there clear thought leaders or influencers?
 - What accounts does the community engage with most?
 
-### Step 4: Present Insights
+### Step 5: Present Insights
 
 Present findings in a clear, organized format. Tailor the depth to the user's request:
 

--- a/plugins/x-content-intelligence/skills/x-insights/SKILL.md
+++ b/plugins/x-content-intelligence/skills/x-insights/SKILL.md
@@ -41,6 +41,11 @@ Ask the user to specify: keywords/hashtags to search, specific accounts to analy
 
 Use Apify by default. Use TweetClaw only when the user already has TweetClaw available and asks to use existing or reviewed X/Twitter source data.
 
+**Retrieving TweetClaw source data:**
+- Use a reviewed TweetClaw export, pasted JSON, saved result file, or OpenClaw/MCP tool output supplied by the user.
+- When the user asks for fresh TweetClaw evidence and the tool is installed, run only source-collection actions such as search tweets, search tweet replies, user lookup, follower export, media lookup, or existing monitor, webhook, or giveaway evidence retrieval.
+- If no reviewed TweetClaw data or tool access is available, use Apify or ask the user for source data.
+
 **TweetClaw source data should stay evidence-only:**
 - Use search tweets, search tweet replies, user lookup, follower export, media context, monitor results, webhook events, or giveaway draw evidence as source material.
 - Keep TweetClaw results as citations, metrics, URLs, IDs, handles, and review notes for the analysis.


### PR DESCRIPTION
## Summary

- Add TweetClaw as an optional reviewed source path for x-content-intelligence.
- Keep Apify as the default scrape path.
- Clarify that TweetClaw outputs are evidence for analysis, while this plugin keeps responsibility for content generation and review.
- Bump the plugin metadata from 0.1.0 to 0.1.1.

## Validation

- `git diff --check`
- `python3.11 -m json.tool .claude-plugin/marketplace.json`
- `python3.11 -m json.tool plugins/x-content-intelligence/.claude-plugin/plugin.json`
- `npx --yes markdown-link-check plugins/x-content-intelligence/README.md plugins/x-content-intelligence/skills/x-insights/SKILL.md`
- `bash scripts/package-plugin.sh x-content-intelligence /tmp/tweetclaw-msapps-dist`
- `bash scripts/sosa-lint.sh .`

## Link Notes

- The changed x-content-intelligence README links pass.
- The changed x-insights skill has no links.
- A root README link check also surfaced pre-existing target-owned blockers outside this PR: `https://claude.ai` returns 403 to curl and `https://x.com/MSAppsMobile` returns 404.
